### PR TITLE
fix(dependencies): downgrade urllib3 to v1.26.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests~=2.28.1
-urllib3~=2.3.0
+urllib3~=1.26.20


### PR DESCRIPTION
Downgraded urllib3 due to compatibility issues with v2.3.0. This ensures stability and prevents potential runtime errors in dependent services.