### PR TITLE
fix(core): route get_enums() through shared _request() method

### DIFF
--- a/src/swgoh_comlink/swgoh_comlink.py
+++ b/src/swgoh_comlink/swgoh_comlink.py
@@ -143,18 +143,24 @@ class SwgohComlink:
         md = self.get_game_metadata()
         return md["latestGamedataVersion"]
 
-    def _post(
+    def _request(
         self,
+        method: str = "POST",
         url_base: str | None = None,
         endpoint: str | None = None,
         payload: dict | list | None = None,
     ) -> dict | list:
-        """Send a POST request to the comlink service.
+        """Send an HTTP request to the comlink service.
+
+        This is the single gateway for all HTTP communication.  Every public
+        method should route through here so that HMAC authentication, TLS
+        verification, and error handling are applied consistently.
 
         Args:
+            method: HTTP method (``"GET"`` or ``"POST"``).
             url_base: Base URL to use. Defaults to ``self.url_base``.
             endpoint: API endpoint path appended to *url_base*.
-            payload: JSON body for the request.
+            payload: JSON body for the request (ignored for GET requests).
 
         Returns:
             Decoded JSON response (dict or list).
@@ -164,7 +170,7 @@ class SwgohComlink:
         """
         if not url_base:
             url_base = self.url_base
-        post_url = url_base + f"/{endpoint}"
+        request_url = url_base + f"/{endpoint}"
         req_headers = {}
         # If access_key and secret_key are set, perform HMAC security
         if self.hmac:
@@ -172,7 +178,7 @@ class SwgohComlink:
             req_headers = {"X-Date": f"{req_time}"}
             hmac_obj = hmac.new(key=self.secret_key.encode(), digestmod=hashlib.sha256)
             hmac_obj.update(req_time.encode())
-            hmac_obj.update(b"POST")
+            hmac_obj.update(method.upper().encode())
             hmac_obj.update(f"/{endpoint}".encode())
             # json dumps separators needed for compact string formatting required for compatibility with
             # comlink since it is written with javascript as the primary object model
@@ -188,10 +194,25 @@ class SwgohComlink:
             hmac_digest = hmac_obj.hexdigest()
             req_headers["Authorization"] = f"HMAC-SHA256 Credential={self.access_key},Signature={hmac_digest}"
         try:
-            r = requests.post(post_url, json=payload, headers=req_headers, verify=self.verify_ssl)
+            request_kwargs: dict[str, Any] = {"headers": req_headers, "verify": self.verify_ssl}
+            if method.upper() != "GET":
+                request_kwargs["json"] = payload
+            r = requests.request(method.upper(), request_url, **request_kwargs)
             return loads(r.content.decode("utf-8"))
         except requests.RequestException as e:
             raise SwgohComlinkException(e) from e
+
+    def _post(
+        self,
+        url_base: str | None = None,
+        endpoint: str | None = None,
+        payload: dict | list | None = None,
+    ) -> dict | list:
+        """Send a POST request to the comlink service.
+
+        Convenience wrapper around :meth:`_request` for backward compatibility.
+        """
+        return self._request(method="POST", url_base=url_base, endpoint=endpoint, payload=payload)
 
     def get_unit_stats(
         self, request_payload: dict | list, flags: list[str] = None, language: str = None
@@ -257,17 +278,16 @@ class SwgohComlink:
 
     def get_enums(self) -> dict:
         """
-        Get an object containing the game data enums
+        Get an object containing the game data enums.
+
+        Unlike most endpoints, ``/enums`` uses a GET request.  Routing through
+        :meth:`_request` ensures HMAC authentication, ``verify_ssl``, and
+        consistent error handling are applied.
 
         Returns:
             A dictionary containing the game data enums.
         """
-        url = self.url_base + "/enums"
-        try:
-            r = requests.request("GET", url, verify=self.verify_ssl)
-            return loads(r.content.decode("utf-8"))
-        except requests.RequestException as e:
-            raise SwgohComlinkException(e) from e
+        return self._request(method="GET", endpoint="enums")
 
     # alias for non PEP usage of direct endpoint calls
     getEnums = get_enums

--- a/tests/test_get_enums.py
+++ b/tests/test_get_enums.py
@@ -3,30 +3,72 @@ from unittest import TestCase, main, mock
 import requests
 
 from swgoh_comlink import SwgohComlink
+from swgoh_comlink.exceptions import SwgohComlinkException
 
 
 class TestGetEnums(TestCase):
     @mock.patch("requests.request")
     def test_get_enums(self, mock_request):
-        """Test that get_enums() makes a GET request and returns parsed JSON."""
+        """Test that get_enums() makes a GET request via _request() and returns parsed JSON."""
         mock_response = mock.Mock()
         mock_response.content = b'{"CombatType": {"1": "CHARACTER", "2": "SHIP"}}'
         mock_request.return_value = mock_response
 
         comlink = SwgohComlink()
-        en = comlink.get_enums()
+        result = comlink.get_enums()
 
-        mock_request.assert_called_once_with("GET", "http://localhost:3000/enums", verify=True)
-        self.assertIn("CombatType", en)
+        mock_request.assert_called_once_with("GET", "http://localhost:3000/enums", headers={}, verify=True)
+        self.assertIn("CombatType", result)
+
+    @mock.patch("requests.request")
+    def test_get_enums_with_hmac(self, mock_request):
+        """Test that get_enums() applies HMAC authentication when keys are set."""
+        mock_response = mock.Mock()
+        mock_response.content = b'{"CombatType": {"1": "CHARACTER"}}'
+        mock_request.return_value = mock_response
+
+        comlink = SwgohComlink(access_key="test_access", secret_key="test_secret")
+        comlink.get_enums()
+
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[0][0], "GET")
+        self.assertEqual(call_args[0][1], "http://localhost:3000/enums")
+        headers = call_args[1]["headers"]
+        self.assertIn("X-Date", headers)
+        self.assertIn("Authorization", headers)
+        self.assertTrue(headers["Authorization"].startswith("HMAC-SHA256 Credential=test_access,Signature="))
+
+    @mock.patch("requests.request")
+    def test_get_enums_respects_verify_ssl(self, mock_request):
+        """Test that get_enums() passes verify_ssl=False when configured."""
+        mock_response = mock.Mock()
+        mock_response.content = b"{}"
+        mock_request.return_value = mock_response
+
+        comlink = SwgohComlink(verify_ssl=False)
+        comlink.get_enums()
+
+        mock_request.assert_called_once_with("GET", "http://localhost:3000/enums", headers={}, verify=False)
 
     @mock.patch("requests.request", side_effect=requests.ConnectionError("Connection refused"))
     def test_get_enums_connection_error(self, mock_request):
         """Test that get_enums() wraps connection errors in SwgohComlinkException."""
-        from swgoh_comlink.exceptions import SwgohComlinkException
-
         comlink = SwgohComlink()
         with self.assertRaises(SwgohComlinkException):
             comlink.get_enums()
+
+    @mock.patch("requests.request")
+    def test_get_enums_no_json_body_for_get(self, mock_request):
+        """Test that GET requests do not include a json body."""
+        mock_response = mock.Mock()
+        mock_response.content = b"{}"
+        mock_request.return_value = mock_response
+
+        comlink = SwgohComlink()
+        comlink.get_enums()
+
+        call_kwargs = mock_request.call_args[1]
+        self.assertNotIn("json", call_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`get_enums()` bypassed `_post()` and made its own `requests.request()` call, which meant HMAC authentication was never applied, and error handling was duplicated. Generalize `_post()` into a `_request(method)` gateway that supports both GET and POST, then rewrite `get_enums()` as a one-liner that delegates to it. `_post()` is kept as a thin wrapper for backward compatibility.

Closes #59

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] Tests

## Checklist

- [X] My commits follow the [Angular commit convention](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, etc.)
- [X] I have added/updated docstrings with type hints for any new or changed public methods
- [X] I have added unit tests that cover my changes (mocked, not requiring a live comlink service)
- [X] All existing tests still pass (`python -m pytest tests/ -v`)
- [X] Ruff linter passes (`ruff check src/ tests/`)
- [X] I have not bundled unrelated changes in this PR

## Testing
`tests/test_get_enums.py`

Test | What it verifies
-- | --
test_get_enums | GET request with correct URL, headers, and verify=True
test_get_enums_with_hmac (new) | HMAC Authorization and X-Date headers applied when access/secret keys are set
test_get_enums_respects_verify_ssl (new) | verify=False passed when verify_ssl=False
test_get_enums_connection_error | Connection errors wrapped in SwgohComlinkException
test_get_enums_no_json_body_for_get (new) | GET requests do not include a json body kwarg
