### PR TITLE
ci(release): guard release workflow against non-main dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
@@ -70,6 +71,7 @@ jobs:
   # Publish the package to PyPI
   pypi-publish:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     needs:
       - release
     permissions:


### PR DESCRIPTION
## Summary

Add `if: github.ref == 'refs/heads/main'` to both jobs in `release.yml` so that an accidental `workflow_dispatch` from `develop` or a feature branch exits without bumping the version, tagging, or publishing to PyPI.

## Why

`release.yml` currently only has `on: workflow_dispatch:` with no branch restriction. With the new branch model (`develop` for integration, `main` for releases only), it would be easy to dispatch the release workflow from `develop` and accidentally cut a release from un-merged integration work.

The guard is applied per-job because workflow-level `if:` is not valid for `workflow_dispatch`.

## Why not migrate to tag-based triggers

The original review document suggested replacing `workflow_dispatch` with `on: push: tags: ['v*']`. That is correct for workflows that publish in *response* to tags created elsewhere, but this workflow *creates* the tag itself (line 54: `git tag -a "v$VERSION"` and `git push --follow-tags`). Reacting to its own tag would be circular, or require splitting the tag-creation step out into a separate workflow without meaningful benefit. The dispatch-with-guard pattern is the right fit.

## Test plan

- [ ] After merge, dispatch from a non-main branch: `gh workflow run release.yml --ref <feature-branch>` — every job should be skipped (`if` evaluates false).
- [ ] Dispatch from `main` should run normally (do not test the publish path until ready for an actual release; consider commenting out the `pypi-publish` step in a fork first if a smoke test is desired).
- [ ] No regression to the `on: workflow_dispatch:` trigger itself — the workflow still appears in the GitHub Actions UI and accepts manual dispatch.

## Notes

- Action `uses:` lines are intentionally not pinned to SHA in this PR. The repository already configures Dependabot for `github-actions` with `target-branch: develop`, which will pin to SHA organically over the next several update cycles.
- Independent of [#85](https://github.com/swgoh-utils/comlink-python/pull/85) (the trigger-alignment PR). Either order of merge works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)