### PR TITLE
fix(tests): switch HMAC rejection tests from GET to POST endpoint

### DIFF
--- a/tests/integration/test_hmac.py
+++ b/tests/integration/test_hmac.py
@@ -14,6 +14,7 @@ from .conftest import (
     COMLINK_HMAC_URL,
     HMAC_ACCESS_KEY,
     HMAC_SECRET_KEY,
+    TEST_ALLYCODE,
 )
 
 pytestmark = pytest.mark.integration
@@ -48,14 +49,24 @@ def test_hmac_sync_player_request_succeeds(comlink_hmac):
 
 @hmac_configured
 def test_hmac_no_key_rejected():
-    """Sync client without HMAC keys is rejected by the protected endpoint."""
+    """Sync client without HMAC keys is rejected by the protected endpoint.
+
+    Uses a POST endpoint (`playerArena`) because the Comlink HMAC service
+    only enforces HMAC on POST; GET endpoints like `/enums` are
+    unauthenticated.
+    """
     with SwgohComlink(url=COMLINK_HMAC_URL) as client, pytest.raises(SwgohComlinkException):
-        client.get_enums()
+        client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 
 @hmac_configured
 def test_hmac_wrong_key_rejected():
-    """Sync client with wrong secret key is rejected by the protected endpoint."""
+    """Sync client with wrong secret key is rejected by the protected endpoint.
+
+    Uses a POST endpoint (`playerArena`) because the Comlink HMAC service
+    only enforces HMAC on POST; GET endpoints like `/enums` are
+    unauthenticated.
+    """
     with (
         SwgohComlink(
             url=COMLINK_HMAC_URL,
@@ -64,7 +75,7 @@ def test_hmac_wrong_key_rejected():
         ) as client,
         pytest.raises(SwgohComlinkException),
     ):
-        client.get_enums()
+        client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 
 # ── Async: valid HMAC ───────────────────────────────────────────────────
@@ -94,23 +105,33 @@ async def test_hmac_async_player_request_succeeds(async_comlink_hmac):
 @hmac_configured
 @pytest.mark.asyncio
 async def test_hmac_no_key_async_rejected():
-    """Async client without HMAC keys is rejected by the protected endpoint."""
+    """Async client without HMAC keys is rejected by the protected endpoint.
+
+    Uses a POST endpoint (`playerArena`) because the Comlink HMAC service
+    only enforces HMAC on POST; GET endpoints like `/enums` are
+    unauthenticated.
+    """
     async with SwgohComlinkAsync(url=COMLINK_HMAC_URL) as client:
         with pytest.raises(SwgohComlinkException):
-            await client.get_enums()
+            await client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 
 @hmac_configured
 @pytest.mark.asyncio
 async def test_hmac_wrong_key_async_rejected():
-    """Async client with wrong secret key is rejected by the protected endpoint."""
+    """Async client with wrong secret key is rejected by the protected endpoint.
+
+    Uses a POST endpoint (`playerArena`) because the Comlink HMAC service
+    only enforces HMAC on POST; GET endpoints like `/enums` are
+    unauthenticated.
+    """
     async with SwgohComlinkAsync(
         url=COMLINK_HMAC_URL,
         access_key=HMAC_ACCESS_KEY,
         secret_key="wrong_secret_key",
     ) as client:
         with pytest.raises(SwgohComlinkException):
-            await client.get_enums()
+            await client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 
 # ── HMAC header verification ────────────────────────────────────────────


### PR DESCRIPTION
Closes #88

## Summary

The four HMAC rejection tests in `tests/integration/test_hmac.py` (`test_hmac_no_key_rejected`, `test_hmac_wrong_key_rejected`, and their async variants) were calling `client.get_enums()`, which is a **GET** request to `/enums`. The Comlink HMAC service does not enforce HMAC on GET endpoints — only on POST — so the server returned 200 OK regardless of authentication and the expected `SwgohComlinkException` was never raised. All four tests failed with `Failed: DID NOT RAISE`.

This PR switches those tests to call `client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)`, a POST request to `/playerArena` (HMAC-protected). Uses the shared `TEST_ALLYCODE` constant from `conftest.py` so the rejection tests align with the existing `get_player` and `get_player_arena` success tests.

## Why this only surfaced now

Integration tests never ran on PRs targeting `develop` until [#85](https://github.com/swgoh-utils/comlink-python/pull/85) landed and `integration.yml` started triggering on `develop` PRs. PRs to `main` had been skipping these tests because `develop` was not in the trigger list, so the latent bug went unnoticed.

## Verification

Probed a live HMAC-protected Comlink container directly to confirm the diagnosis and exercised the new test code end-to-end:

| Scenario | Endpoint | Result |
|---|---|---|
| no auth | `GET /enums` | 200 OK *(server doesn't protect GET — root cause)* |
| no auth | `POST /playerArena` | 403 `HMACValidationError` (Authorization header missing) |
| wrong secret | `POST /playerArena` | 403 `HMACValidationError` (HMAC validation failed) |
| valid `test_key`/`test_secret` | `POST /playerArena` | 200 OK with real `playerDetailsOnly` response |

All four updated tests `PASS` against the live container.

## Test plan

- [ ] CI Integration Tests check passes on this PR (was failing on every PR since #85 merged due to this bug).
- [ ] Other CI checks (`Lint`, `Type Check`, `Test (Python 3.10..3.13)`, `Docs`, `Build`, `Validate Commit Messages`) remain green.
- [ ] No changes outside `tests/integration/test_hmac.py`; client and server code untouched.

## Notes

- Production HMAC client behavior is correct and unchanged — verified by the existing `test_hmac_*_request_succeeds` tests (which continue to pass) and by the positive-control valid-auth probe in this PR's verification.
- Bug was purely in test scaffolding.

Generated with [Claude Code](https://claude.com/claude-code)
