### PR TITLE
feat(helpers): add localization dictionary parsing with sync and async support

### DIFF
--- a/src/swgoh_comlink/helpers/__init__.py
+++ b/src/swgoh_comlink/helpers/__init__.py
@@ -22,10 +22,12 @@ from ._gac import (
     search_gac_brackets,
 )
 from ._game_data import (
+    async_get_localization_dictionary,
     create_localized_unit_name_dictionary,
     get_current_datacron_sets,
     get_datacron_dismantle_total,
     get_datacron_dismantle_value,
+    get_localization_dictionary,
     get_playable_units,
     get_raid_leaderboard_ids,
 )
@@ -99,10 +101,12 @@ __all__ = [
     # Conquest
     "calc_current_stamina",
     # Game data
+    "async_get_localization_dictionary",
     "create_localized_unit_name_dictionary",
     "get_current_datacron_sets",
     "get_datacron_dismantle_total",
     "get_datacron_dismantle_value",
+    "get_localization_dictionary",
     "get_playable_units",
     "get_raid_leaderboard_ids",
     # Guild

--- a/src/swgoh_comlink/helpers/_game_data.py
+++ b/src/swgoh_comlink/helpers/_game_data.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import base64
+import io
 import logging
 import time
+import zipfile
 from math import floor
 from typing import Any
 
@@ -93,6 +96,105 @@ def create_localized_unit_name_dictionary(locale: str | list[Any]) -> dict[str, 
             if name_key.endswith("_NAME"):
                 unit_name_map[name_key] = desc
     return unit_name_map
+
+
+def _parse_localization_bundle(bundle: dict[str, Any], language: str) -> dict[str, str]:
+    """Decode a ``get_localization()`` response and parse one language file into a dictionary.
+
+    The Comlink ``localization`` endpoint returns a base64-encoded zip archive under the
+    ``localizationBundle`` key. Each archive entry is a newline-delimited text file whose lines
+    are ``KEY|value`` pairs (``#`` prefixed lines are comments).
+
+    Args:
+        bundle: The dictionary returned by ``SwgohComlink.get_localization()``.
+        language: Locale identifier (e.g. ``"eng_us"``) used to select the ``Loc_<LANG>.txt`` entry.
+
+    Returns:
+        A dictionary mapping localization keys to their localized string values.
+
+    Raises:
+        SwgohComlinkValueError: If the response is missing the ``localizationBundle`` key or the
+            archive does not contain a file for the requested language.
+
+    """
+    if "localizationBundle" not in bundle:
+        err_msg = f"{get_function_name()}: response is missing the 'localizationBundle' key."
+        raise SwgohComlinkValueError(err_msg)
+
+    decoded = base64.b64decode(bundle["localizationBundle"])
+    target = f"Loc_{language.upper()}.txt"
+    result: dict[str, str] = {}
+    with zipfile.ZipFile(io.BytesIO(decoded)) as zip_obj:
+        names = zip_obj.namelist()
+        if target not in names:
+            err_msg = f"{get_function_name()}: '{target}' not found in localization bundle (available: {names})."
+            raise SwgohComlinkValueError(err_msg)
+        with zip_obj.open(target) as raw, io.TextIOWrapper(raw, encoding="utf-8") as stream:
+            for line in stream:
+                if line.startswith("#"):
+                    continue
+                key, sep, value = line.rstrip("\r\n").partition("|")
+                if sep:
+                    result[key] = value
+    return result
+
+
+def get_localization_dictionary(comlink: Any, language: str = "eng_us") -> dict[str, str]:
+    """Fetch a localization bundle and parse it into a key/value dictionary.
+
+    Args:
+        comlink: Instance of SwgohComlink.
+        language: Locale identifier to retrieve. [Default: ``"eng_us"``]
+
+    Returns:
+        A dictionary mapping localization keys to their localized string values.
+
+    Raises:
+        SwgohComlinkValueError: If ``comlink`` is not a SwgohComlink instance, or the response
+            cannot be parsed for the requested language.
+
+    """
+    comlink_type = getattr(comlink, "__comlink_type__", None)
+    if comlink_type != "SwgohComlink":
+        err_msg = f"{get_function_name()}: The 'comlink' argument is required and must be an instance of SwgohComlink."
+        raise SwgohComlinkValueError(err_msg)
+
+    if not isinstance(language, str) or not language:
+        err_msg = f"{get_function_name()}: 'language' must be a non-empty string."
+        raise SwgohComlinkValueError(err_msg)
+
+    bundle = comlink.get_localization(locale=language)
+    return _parse_localization_bundle(bundle, language)
+
+
+async def async_get_localization_dictionary(comlink: Any, language: str = "eng_us") -> dict[str, str]:
+    """Fetch a localization bundle and parse it into a key/value dictionary (async version).
+
+    Args:
+        comlink: Instance of SwgohComlinkAsync.
+        language: Locale identifier to retrieve. [Default: ``"eng_us"``]
+
+    Returns:
+        A dictionary mapping localization keys to their localized string values.
+
+    Raises:
+        SwgohComlinkValueError: If ``comlink`` is not a SwgohComlinkAsync instance, or the response
+            cannot be parsed for the requested language.
+
+    """
+    comlink_type = getattr(comlink, "__comlink_type__", None)
+    if comlink_type != "SwgohComlinkAsync":
+        err_msg = (
+            f"{get_function_name()}: The 'comlink' argument is required and must be an instance of SwgohComlinkAsync."
+        )
+        raise SwgohComlinkValueError(err_msg)
+
+    if not isinstance(language, str) or not language:
+        err_msg = f"{get_function_name()}: 'language' must be a non-empty string."
+        raise SwgohComlinkValueError(err_msg)
+
+    bundle = await comlink.get_localization(locale=language)
+    return _parse_localization_bundle(bundle, language)
 
 
 def get_playable_units(units_collection: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/unit/test_helpers_mocked.py
+++ b/tests/unit/test_helpers_mocked.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import io
+import zipfile
 from unittest.mock import patch
 
 import pytest
@@ -365,3 +368,116 @@ class TestCalcCurrentStamina:
         }
         result = calc_current_stamina(old_unit)
         assert result == 100
+
+
+# ── _game_data: get_localization_dictionary (sync + async) ───────────────
+
+_METADATA = {"latestGamedataVersion": "g1", "latestLocalizationBundleVersion": "loc-v1"}
+
+
+def _make_loc_bundle(*entries: tuple[str, str]) -> dict[str, str]:
+    """Build a base64-encoded zip mimicking the Comlink localization response.
+
+    Args:
+        *entries: (filename, text_content) pairs to add to the archive.
+
+    Returns:
+        A dict of the form ``{"localizationBundle": "<base64 zip>"}``.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries:
+            zf.writestr(name, content)
+    return {"localizationBundle": base64.b64encode(buf.getvalue()).decode("utf-8")}
+
+
+_ENG_CONTENT = "UNIT_A|Vader\n#comment line\nUNIT_B|Yoda\n"
+
+
+class TestGetLocalizationDictionary:
+    def test_parses_default_language(self, httpx_mock: HTTPXMock, sync_client):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        httpx_mock.add_response(json=_METADATA)  # get_metadata() lookup
+        httpx_mock.add_response(json=_make_loc_bundle(("Loc_ENG_US.txt", _ENG_CONTENT)))
+        result = get_localization_dictionary(sync_client)
+        assert result == {"UNIT_A": "Vader", "UNIT_B": "Yoda"}
+
+    def test_parses_non_default_language(self, httpx_mock: HTTPXMock, sync_client):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        httpx_mock.add_response(json=_METADATA)
+        httpx_mock.add_response(json=_make_loc_bundle(("Loc_FRE_FR.txt", "UNIT_A|Vador\n")))
+        result = get_localization_dictionary(sync_client, language="fre_fr")
+        assert result == {"UNIT_A": "Vador"}
+
+    def test_missing_bundle_key_raises(self, httpx_mock: HTTPXMock, sync_client):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        httpx_mock.add_response(json=_METADATA)
+        httpx_mock.add_response(json={"notTheBundle": "oops"})
+        with pytest.raises(SwgohComlinkValueError, match="localizationBundle"):
+            get_localization_dictionary(sync_client)
+
+    def test_language_not_in_bundle_raises(self, httpx_mock: HTTPXMock, sync_client):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        httpx_mock.add_response(json=_METADATA)
+        httpx_mock.add_response(json=_make_loc_bundle(("Loc_ENG_US.txt", _ENG_CONTENT)))
+        with pytest.raises(SwgohComlinkValueError, match="Loc_FRE_FR.txt"):
+            get_localization_dictionary(sync_client, language="fre_fr")
+
+    def test_missing_comlink_raises(self):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        with pytest.raises(SwgohComlinkValueError, match="comlink"):
+            get_localization_dictionary(None)
+
+    def test_wrong_comlink_type_raises(self):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        with pytest.raises(SwgohComlinkValueError, match="comlink"):
+            get_localization_dictionary(object())
+
+    @pytest.mark.parametrize("bad_language", ["", None, 123])
+    def test_invalid_language_raises(self, sync_client, bad_language):
+        from swgoh_comlink.helpers._game_data import get_localization_dictionary
+
+        # Guard fires before any HTTP call, so no mocked response is queued.
+        with pytest.raises(SwgohComlinkValueError, match="non-empty string"):
+            get_localization_dictionary(sync_client, language=bad_language)
+
+
+class TestAsyncGetLocalizationDictionary:
+    @pytest.mark.asyncio
+    async def test_parses_default_language(self, httpx_mock: HTTPXMock, async_client):
+        from swgoh_comlink.helpers._game_data import async_get_localization_dictionary
+
+        httpx_mock.add_response(json=_METADATA)
+        httpx_mock.add_response(json=_make_loc_bundle(("Loc_ENG_US.txt", _ENG_CONTENT)))
+        result = await async_get_localization_dictionary(async_client)
+        assert result == {"UNIT_A": "Vader", "UNIT_B": "Yoda"}
+
+    @pytest.mark.asyncio
+    async def test_language_not_in_bundle_raises(self, httpx_mock: HTTPXMock, async_client):
+        from swgoh_comlink.helpers._game_data import async_get_localization_dictionary
+
+        httpx_mock.add_response(json=_METADATA)
+        httpx_mock.add_response(json=_make_loc_bundle(("Loc_ENG_US.txt", _ENG_CONTENT)))
+        with pytest.raises(SwgohComlinkValueError, match="Loc_FRE_FR.txt"):
+            await async_get_localization_dictionary(async_client, language="fre_fr")
+
+    @pytest.mark.asyncio
+    async def test_wrong_comlink_type_raises(self):
+        from swgoh_comlink.helpers._game_data import async_get_localization_dictionary
+
+        with pytest.raises(SwgohComlinkValueError, match="comlink"):
+            await async_get_localization_dictionary(object())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_language", ["", None, 123])
+    async def test_invalid_language_raises(self, async_client, bad_language):
+        from swgoh_comlink.helpers._game_data import async_get_localization_dictionary
+
+        with pytest.raises(SwgohComlinkValueError, match="non-empty string"):
+            await async_get_localization_dictionary(async_client, language=bad_language)


### PR DESCRIPTION
## Summary

Adds a reusable helper that fetches a game localization bundle through a comlink instance and parses it into a flat `dict[str, str]` — promoting the parsing convention that previously lived only in `examples/Sync/get_location_bundle_adv.py` into the library.

## API

```python
from swgoh_comlink import SwgohComlink
from swgoh_comlink.helpers import get_localization_dictionary

comlink = SwgohComlink(url="http://localhost:3000")
loc = get_localization_dictionary(comlink)                 # defaults to "eng_us"
fr  = get_localization_dictionary(comlink, language="fre_fr")
```

- `get_localization_dictionary(comlink, language="eng_us")` and its async twin `async_get_localization_dictionary`.
- A shared `_parse_localization_bundle` decodes the base64-zipped response and parses the `Loc_<LANG>.txt` entry into `{key: value}` pairs (skips `#` comments, splits on `|`).
- Validates inputs up front with `SwgohComlinkValueError`: rejects a wrong/`None` comlink type and a non-string/empty `language` **before** any network call. Unknown-but-well-formed locales are left to the server's `400`.

**Files:** `src/swgoh_comlink/helpers/_game_data.py`, `helpers/__init__.py` (exports), `tests/unit/test_helpers_mocked.py`.

## Testing
- New sync + async mocked tests cover: happy path, non-default language, missing `localizationBundle` key, requested language absent from bundle, invalid comlink type, and invalid `language` type.
- `uv run pytest tests/unit/test_helpers_mocked.py` — 50 passed.
- Live smoke test against a running comlink instance: sync and async return an 87,744-key dictionary, distinct per language, with sync == async output.

## Notes
- Purely additive; no public API removed.
- Independent of the mypy→ty migration PR — this branch is green under the current CI and cleanly typed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
