### PR TITLE
ci(ci): exempt mergeback PRs from commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -42,4 +42,24 @@ jobs:
           EOF
 
       - name: Validate commits
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin main
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          # Lint only the commits this PR actually introduces: exclude merge
+          # commits and any commit already reachable from main. Mergeback and
+          # automated back-merge PRs re-introduce main's (sometimes
+          # non-conventional squash) commits — those are already on main and are
+          # not this PR's responsibility to police.
+          commits="$(git rev-list --no-merges --reverse "${base}..${head}" --not FETCH_HEAD)"
+          if [ -z "${commits}" ]; then
+            echo "No PR-unique commits to lint (mergeback/back-merge or merge-only PR)."
+            exit 0
+          fi
+          rc=0
+          while read -r sha; do
+            echo "── ${sha} ──"
+            git log -1 --format=%B "${sha}" | npx commitlint --verbose || rc=1
+          done <<< "${commits}"
+          exit "${rc}"


### PR DESCRIPTION
Follow-up to #109, which landed the changelog tooling but **not** this commitlint fix — the fix commit was pushed after #109 was merged, so it never reached develop.

**Problem:** the commitlint job lints the entire PR range (`--from base --to head`). Mergeback PRs (like #110) and the automated `backmerge.yml` PRs re-introduce `main`'s own commits — including non-conventional squash titles like #106 (`Update GitHub Actions checkout from v6 to v7`) — which then fail `type-empty`/`subject-empty`.

**Fix:** lint only the commits a PR actually introduces that are **not already on `main`**, and skip merge commits (`git rev-list --no-merges base..head --not FETCH_HEAD`). Feature PRs stay strict; mergeback/back-merge PRs pass.

Verified locally: mergeback range → empty (exempt); a normal feature range → still lists its conventional commits.

Once merged, re-running commitlint on #110 should pass (its merge-ref picks up the updated develop).
