### PR TITLE
chore(release): render docs in the changelog and widen the commitlint scopes

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -30,8 +30,10 @@ jobs:
                 "chore", "docs", "test", "tests", "style", "ci", "perf"
               ]],
               "scope-enum": [1, "always", [
-                "core", "helpers", "deps", "release", "ci",
-                "version", "hmac", "docs", "tests", "examples"
+                "core", "helpers", "client", "auth", "statcalc",
+                "exceptions", "cache", "defaults", "typing", "hmac",
+                "version", "deps", "release", "changelog", "ci",
+                "docs", "tests", "examples", "parity"
               ]],
               "subject-max-length": [1, "always", 100],
               "header-max-length": [0, "always"],

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -64,7 +64,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${branch}"
           git add CHANGELOG.md
-          git commit -m "docs(changelog): update for ${tag}"
+          # `chore` keeps this bookkeeping commit out of the rendered sections;
+          # `docs` would list every release's regeneration in the next release.
+          git commit -m "chore(changelog): update for ${tag}"
           git push --force-with-lease origin "${branch}"
           gh pr create \
             --base main --head "${branch}" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,9 @@ in-place = true
 output = "CHANGELOG.md"
 marker-line = "<!-- insertion marker -->"
 bump = "auto"
+# The angular convention renders only feat/fix/revert/refactor/perf by default.
+# Listing them explicitly is what lets `docs` join them.
+sections = ["feat", "fix", "revert", "refactor", "perf", "docs"]
 
 # ── Coverage ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
> **Stacked on #123 — this PR targets `fix/integration-items-param`, not `develop`.**
> It cannot merge until #123 lands. GitHub retargets this PR to `develop` automatically once #123 is merged. The diff shown here is only this branch's three commits.

Changelog generation currently drops every `docs` commit, and duplicates entries for single-commit PRs.

## Changes

**Render the `docs` section** — `[tool.git-changelog]` set no `sections` key, so only the angular convention's defaults (`feat`, `fix`, `revert`, `refactor`, `perf`) reached the changelog. Supplying `sections` replaces the default list rather than extending it, so the defaults are spelled out alongside `docs`.

**Keep the release bookkeeping commit out of the rendered sections** — `prepare-release.yml` committed the regenerated changelog as `docs(changelog): update for ${tag}`. With `docs` now rendered, every release would list the previous release's own changelog regeneration. Changed to `chore(changelog)`, which is not in the render list.

**Cover the scopes actually in use in the commitlint enum** — surveyed the scopes appearing in real commits against the allowed list. Nine were missing and all map to real code areas: `client`, `auth`, `statcalc`, `exceptions`, `cache`, `defaults`, `typing`, `parity`, and `changelog`. The rule is warn-only, so nothing was failing, but the warnings were noise.

Deliberately omitted: `contributing` and `dependabot`, used once each and already covered by `docs` and `deps`.

## Note

This does not fix the duplicate-entry problem itself. That was caused by the repository's `merge_commit_title` setting being `PR_TITLE`, which gave every merge commit a subject identical to the underlying commit on single-commit PRs. That setting has been changed to `MERGE_MESSAGE` and needs no code change. Existing history is unaffected, so the v2.3.0 changelog will still show the #117 cache feature twice unless that line is removed by hand on the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
