### PR TITLE
ci(release): stage the release PR instead of opening it, and move to comlink 4.4.2

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,8 +21,8 @@ jobs:
     services:
       # Pinned deliberately: on `latest`, an upstream Comlink release lands in CI with no
       # commit of ours, so a red suite carries no information about the change under test.
-      # Bump this tag on purpose. 4.4.1 is the current release and matches what `latest`
-      # resolved to when this was pinned.
+      # Bump this tag on purpose, and keep both services on the same tag.
+      # 4.4.2 fixes the /data fetch that 4.4.0 and 4.4.1 could not complete.
       comlink:
         image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
         env:
@@ -31,7 +31,7 @@ jobs:
           - 3000:3000
 
       comlink-hmac:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
         env:
           APP_NAME: comlink-python-hmac-integration-tests
           ACCESS_KEY: ${{ secrets.COMLINK_ACCESS_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,9 +1,16 @@
 name: prepare release
 
 # Manually dispatched from `develop`. Computes the next version from Conventional
-# Commits, regenerates CHANGELOG.md, and opens a PR into `main`. The PR carries the
-# full develop payload plus the changelog commit, so merging it promotes develop ->
+# Commits, regenerates CHANGELOG.md, and pushes a `release/<tag>` branch carrying the
+# full develop payload plus the changelog commit. Merging that branch promotes develop ->
 # main with the changelog already in place — BEFORE the release workflow cuts the tag.
+#
+# This workflow deliberately does NOT open the pull request. Opening it here would make
+# the PR authored by github-actions[bot], and a bot-authored PR does not trigger the
+# `pull_request` workflows (CI, Integration Tests, Commit Lint) that gate `main` — the
+# release would arrive unverified. Instead the release PR text is written to a file on
+# the release branch and a prefilled "create PR" link is put in the job summary, so a
+# maintainer opens it in two clicks and the checks run as normal.
 
 on:
   workflow_dispatch:
@@ -16,11 +23,10 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   prepare:
-    name: Regenerate changelog and open release PR
+    name: Regenerate changelog and stage the release branch
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
     steps:
@@ -53,9 +59,31 @@ jobs:
       - name: Regenerate CHANGELOG.md
         run: uv run git-changelog --bump '${{ inputs.bump }}'
 
-      - name: Open release PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Write the release PR text
+        id: pr_text
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          body_file=".github/release-pr/${tag}.md"
+          mkdir -p "$(dirname "${body_file}")"
+
+          # Pull just this version's section out of the freshly regenerated changelog:
+          # start at its anchor, stop at the next one.
+          notes="$(awk -v t="${tag}" \
+            'BEGIN{p="^<a name=\""t"\"></a>$"} $0 ~ p {f=1} f && /^<a name=/ && ++n>1 {exit} f' \
+            CHANGELOG.md)"
+
+          {
+            printf 'Automated release prep for **%s**. CHANGELOG.md regenerated via git-changelog.\n\n' "${tag}"
+            printf 'Merging promotes `develop` -> `main` with the changelog already in place.\n'
+            printf 'Afterwards, run the **release** workflow on `main` to build, publish, and tag %s.\n\n' "${tag}"
+            printf -- '---\n\n'
+            printf '%s\n' "${notes}"
+          } > "${body_file}"
+
+          echo "body_file=${body_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Push the release branch
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
@@ -63,12 +91,30 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${branch}"
-          git add CHANGELOG.md
+          git add CHANGELOG.md "${{ steps.pr_text.outputs.body_file }}"
           # `chore` keeps this bookkeeping commit out of the rendered sections;
           # `docs` would list every release's regeneration in the next release.
           git commit -m "chore(changelog): update for ${tag}"
           git push --force-with-lease origin "${branch}"
-          gh pr create \
-            --base main --head "${branch}" \
-            --title "chore(release): ${tag}" \
-            --body "Automated release prep for **${tag}**. Regenerated CHANGELOG.md via git-changelog. Merging promotes develop -> main; then run the release workflow on main to build, publish, and tag ${tag}."
+
+      - name: Summarise how to open the release PR
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          branch="release/${tag}"
+          body_file="${{ steps.pr_text.outputs.body_file }}"
+          title="chore(release): ${tag}"
+          # Only the title is prefilled via the URL: bodies routinely exceed what a query
+          # string can carry, so the body is copied from the file on the branch instead.
+          encoded_title="$(jq -rn --arg t "${title}" '$t|@uri')"
+          url="${{ github.server_url }}/${{ github.repository }}/compare/main...${branch}?expand=1&title=${encoded_title}"
+
+          {
+            printf '## %s is staged\n\n' "${tag}"
+            printf 'Branch `%s` is pushed. Open the PR manually — a bot-authored PR would not run the `pull_request` checks that gate `main`.\n\n' "${branch}"
+            printf '### [→ Open the release PR](%s)\n\n' "${url}"
+            printf 'Base `main`, head `%s`, title:\n\n```\n%s\n```\n\n' "${branch}" "${title}"
+            printf 'The body below is also committed to `%s` on that branch — copy it in:\n\n' "${body_file}"
+            printf -- '---\n\n'
+            cat "${body_file}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -3,24 +3,10 @@
 import pytest
 
 from swgoh_comlink import SwgohComlinkAsync
-from swgoh_comlink.exceptions import SwgohComlinkException
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
-
-# A cold service container in CI cannot complete a /data fetch from the upstream game
-# servers: every form of the request fails with HTTP 400 and the body "Did not receive a
-# response code back from the server, even after a retry." The trailing hint about the
-# parameter being invalid is boilerplate — request_segment, a Segment aggregate, and a
-# single collection value all fail identically, on both 4.4.0 and 4.4.1, while every
-# other endpoint works. Nothing in this library can fix that, so the /data tests are
-# expected to fail there. Non-strict on purpose: they pass against a warm instance, and
-# an XPASS is the signal that upstream has recovered and this marker can come off.
-data_endpoint_unavailable = pytest.mark.xfail(
-    raises=SwgohComlinkException,
-    reason="upstream /data fetch fails on a cold CI service container",
-)
 
 
 async def test_get_enums(async_comlink):
@@ -93,7 +79,6 @@ async def test_get_guilds_by_name(async_comlink):
     assert len(result["guild"]) > 0
 
 
-@data_endpoint_unavailable
 async def test_get_game_data_filtered(async_comlink):
     """POST /data with a single items collection populates that collection and no other.
 

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -3,24 +3,10 @@
 import pytest
 
 from swgoh_comlink import SwgohComlink
-from swgoh_comlink.exceptions import SwgohComlinkException
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
 pytestmark = pytest.mark.integration
-
-# A cold service container in CI cannot complete a /data fetch from the upstream game
-# servers: every form of the request fails with HTTP 400 and the body "Did not receive a
-# response code back from the server, even after a retry." The trailing hint about the
-# parameter being invalid is boilerplate — request_segment, a Segment aggregate, and a
-# single collection value all fail identically, on both 4.4.0 and 4.4.1, while every
-# other endpoint works. Nothing in this library can fix that, so the /data tests are
-# expected to fail there. Non-strict on purpose: they pass against a warm instance, and
-# an XPASS is the signal that upstream has recovered and this marker can come off.
-data_endpoint_unavailable = pytest.mark.xfail(
-    raises=SwgohComlinkException,
-    reason="upstream /data fetch fails on a cold CI service container",
-)
 
 
 def test_get_enums(comlink):
@@ -93,7 +79,6 @@ def test_get_guilds_by_name(comlink):
     assert len(result["guild"]) > 0
 
 
-@data_endpoint_unavailable
 def test_get_game_data_filtered(comlink):
     """POST /data with a single items collection populates that collection and no other.
 


### PR DESCRIPTION
Two things: move the integration services to Comlink 4.4.2, and stop `prepare-release` from opening the release PR itself.

## Comlink 4.4.2

4.4.2 fixes the `/data` fetch that neither 4.4.0 nor 4.4.1 could complete, so the two `/data` tests are no longer quarantined — the `xfail` markers and their now-unused `SwgohComlinkException` imports are gone, and the tests assert normally again.

Both services move to `4.4.2`. The `comlink-hmac` service had been left on `4.4.1`; running the two on different builds means the HMAC tests exercise a different server than the rest of the suite, so the pin comment now says to keep them in step.

## prepare-release no longer opens the PR

`gh pr create` is removed. The workflow now:

1. writes the PR body to `.github/release-pr/<tag>.md`, including the new version's changelog section extracted from the regenerated `CHANGELOG.md`;
2. commits that file alongside `CHANGELOG.md` and pushes `release/<tag>`;
3. writes a job summary with a prefilled *"Open the release PR"* link (base `main`, head `release/<tag>`, title prefilled), plus the body text inline for copy-paste.

`permissions` drops to `contents: write`, and the `GH_TOKEN` env goes away — nothing calls the API any more.

### Why this is better than a bot-opened PR

A PR opened by `github-actions[bot]` using the default `GITHUB_TOKEN` does not trigger `pull_request` workflows. CI, Integration Tests, and Commit Lint all gate on `pull_request` against `main`, so the release PR would have arrived with no checks at all. Having a maintainer open it means the full suite runs before `main` moves.

### The body-file tradeoff

The file lives on the release branch, so merging the release PR carries `.github/release-pr/<tag>.md` into `main` — over time that accumulates one small markdown file per release. That is a deliberate choice: it makes the PR text a durable, reviewable artifact rather than something that exists only in a job summary that ages out.

If you would rather `main` stay clean, two alternatives need only a small edit: upload the body as a workflow artifact instead of committing it, or keep the job summary alone. Both drop the permanent record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
