### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/.github/release-pr/v2.3.0.md
+++ b/.github/release-pr/v2.3.0.md
@@ -1,0 +1,26 @@
+Automated release prep for **v2.3.0**. CHANGELOG.md regenerated via git-changelog.
+
+Merging promotes `develop` -> `main` with the changelog already in place.
+Afterwards, run the **release** workflow on `main` to build, publish, and tag v2.3.0.
+
+---
+
+<a name="v2.3.0"></a>
+
+## [v2.3.0](https://github.com/swgoh-utils/comlink-python/compare/v2.2.0...v2.3.0) (2026-08-03)
+
+### Features
+
+- **cache:** cache game/localization versions from /metadata with configurable TTL (#117) ([d351759](https://github.com/swgoh-utils/comlink-python/commit/d35175900932c79e5836f383fb6b3ce8dd39f6d9))
+- **cache:** cache game/localization versions from /metadata with configurable TTL ([8cdd771](https://github.com/swgoh-utils/comlink-python/commit/8cdd7719619ac7b83ceb66c069825572e17d018a))
+
+### Bug Fixes
+
+- **hmac:** sign the bytes actually sent so empty-payload POSTs validate ([943fd7f](https://github.com/swgoh-utils/comlink-python/commit/943fd7ff490813a74ad50d7c4e4c35ef76b3e79d))
+- **tests:** call get_game_data with items= instead of the rejected request_segment ([60c19bf](https://github.com/swgoh-utils/comlink-python/commit/60c19bf390818d0610802a1cd3a3ca7f1cb59829))
+- **client:** send clientSpecs key expected by /metadata endpoint ([1909912](https://github.com/swgoh-utils/comlink-python/commit/1909912fc10b1deb822b816b46a0e7577da7e422))
+- **exceptions:** stop logging tracebacks from exception constructors ([f841fa8](https://github.com/swgoh-utils/comlink-python/commit/f841fa88bd64abc6a66326ee0654e367976733ce))
+
+### Docs
+
+- **changelog:** update for v2.2.0 ([7b917de](https://github.com/swgoh-utils/comlink-python/commit/7b917dea5ce146c2cce9bbd90b436ba010f01207))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -49,7 +49,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -74,7 +74,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -107,7 +107,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -128,7 +128,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -30,8 +30,10 @@ jobs:
                 "chore", "docs", "test", "tests", "style", "ci", "perf"
               ]],
               "scope-enum": [1, "always", [
-                "core", "helpers", "deps", "release", "ci",
-                "version", "hmac", "docs", "tests", "examples"
+                "core", "helpers", "client", "auth", "statcalc",
+                "exceptions", "cache", "defaults", "typing", "hmac",
+                "version", "deps", "release", "changelog", "ci",
+                "docs", "tests", "examples", "parity"
               ]],
               "subject-max-length": [1, "always", 100],
               "header-max-length": [0, "always"],

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,14 +23,14 @@ jobs:
       # with no commit of ours and can turn the suite red (4.4.x deprecated the
       # `requestSegment` parameter this way). Bump this tag on purpose.
       comlink:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.0
         env:
           APP_NAME: comlink-python-integration-tests
         ports:
           - 3000:3000
 
       comlink-hmac:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.0
         env:
           APP_NAME: comlink-python-hmac-integration-tests
           ACCESS_KEY: ${{ secrets.COMLINK_ACCESS_KEY }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,18 +19,19 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     services:
-      # Pinned deliberately: on `latest`, an upstream Comlink release lands in CI
-      # with no commit of ours and can turn the suite red (4.4.x deprecated the
-      # `requestSegment` parameter this way). Bump this tag on purpose.
+      # Pinned deliberately: on `latest`, an upstream Comlink release lands in CI with no
+      # commit of ours, so a red suite carries no information about the change under test.
+      # Bump this tag on purpose. 4.4.1 is the current release and matches what `latest`
+      # resolved to when this was pinned.
       comlink:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.0
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
         env:
           APP_NAME: comlink-python-integration-tests
         ports:
           - 3000:3000
 
       comlink-hmac:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.0
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
         env:
           APP_NAME: comlink-python-hmac-integration-tests
           ACCESS_KEY: ${{ secrets.COMLINK_ACCESS_KEY }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
       # Bump this tag on purpose. 4.4.1 is the current release and matches what `latest`
       # resolved to when this was pinned.
       comlink:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
         env:
           APP_NAME: comlink-python-integration-tests
         ports:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,7 +59,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,8 +21,8 @@ jobs:
     services:
       # Pinned deliberately: on `latest`, an upstream Comlink release lands in CI with no
       # commit of ours, so a red suite carries no information about the change under test.
-      # Bump this tag on purpose. 4.4.1 is the current release and matches what `latest`
-      # resolved to when this was pinned.
+      # Bump this tag on purpose, and keep both services on the same tag.
+      # 4.4.2 fixes the /data fetch that 4.4.0 and 4.4.1 could not complete.
       comlink:
         image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
         env:
@@ -31,7 +31,7 @@ jobs:
           - 3000:3000
 
       comlink-hmac:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
         env:
           APP_NAME: comlink-python-hmac-integration-tests
           ACCESS_KEY: ${{ secrets.COMLINK_ACCESS_KEY }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,15 +19,18 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     services:
+      # Pinned deliberately: on `latest`, an upstream Comlink release lands in CI
+      # with no commit of ours and can turn the suite red (4.4.x deprecated the
+      # `requestSegment` parameter this way). Bump this tag on purpose.
       comlink:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:latest
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
         env:
           APP_NAME: comlink-python-integration-tests
         ports:
           - 3000:3000
 
       comlink-hmac:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:latest
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.1
         env:
           APP_NAME: comlink-python-hmac-integration-tests
           ACCESS_KEY: ${{ secrets.COMLINK_ACCESS_KEY }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v7
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: false

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -64,7 +64,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${branch}"
           git add CHANGELOG.md
-          git commit -m "docs(changelog): update for ${tag}"
+          # `chore` keeps this bookkeeping commit out of the rendered sections;
+          # `docs` would list every release's regeneration in the next release.
+          git commit -m "chore(changelog): update for ${tag}"
           git push --force-with-lease origin "${branch}"
           gh pr create \
             --base main --head "${branch}" \

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,9 +1,16 @@
 name: prepare release
 
 # Manually dispatched from `develop`. Computes the next version from Conventional
-# Commits, regenerates CHANGELOG.md, and opens a PR into `main`. The PR carries the
-# full develop payload plus the changelog commit, so merging it promotes develop ->
+# Commits, regenerates CHANGELOG.md, and pushes a `release/<tag>` branch carrying the
+# full develop payload plus the changelog commit. Merging that branch promotes develop ->
 # main with the changelog already in place — BEFORE the release workflow cuts the tag.
+#
+# This workflow deliberately does NOT open the pull request. Opening it here would make
+# the PR authored by github-actions[bot], and a bot-authored PR does not trigger the
+# `pull_request` workflows (CI, Integration Tests, Commit Lint) that gate `main` — the
+# release would arrive unverified. Instead the release PR text is written to a file on
+# the release branch and a prefilled "create PR" link is put in the job summary, so a
+# maintainer opens it in two clicks and the checks run as normal.
 
 on:
   workflow_dispatch:
@@ -16,11 +23,10 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   prepare:
-    name: Regenerate changelog and open release PR
+    name: Regenerate changelog and stage the release branch
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
     steps:
@@ -53,9 +59,31 @@ jobs:
       - name: Regenerate CHANGELOG.md
         run: uv run git-changelog --bump '${{ inputs.bump }}'
 
-      - name: Open release PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Write the release PR text
+        id: pr_text
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          body_file=".github/release-pr/${tag}.md"
+          mkdir -p "$(dirname "${body_file}")"
+
+          # Pull just this version's section out of the freshly regenerated changelog:
+          # start at its anchor, stop at the next one.
+          notes="$(awk -v t="${tag}" \
+            'BEGIN{p="^<a name=\""t"\"></a>$"} $0 ~ p {f=1} f && /^<a name=/ && ++n>1 {exit} f' \
+            CHANGELOG.md)"
+
+          {
+            printf 'Automated release prep for **%s**. CHANGELOG.md regenerated via git-changelog.\n\n' "${tag}"
+            printf 'Merging promotes `develop` -> `main` with the changelog already in place.\n'
+            printf 'Afterwards, run the **release** workflow on `main` to build, publish, and tag %s.\n\n' "${tag}"
+            printf -- '---\n\n'
+            printf '%s\n' "${notes}"
+          } > "${body_file}"
+
+          echo "body_file=${body_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Push the release branch
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
@@ -63,12 +91,30 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${branch}"
-          git add CHANGELOG.md
+          git add CHANGELOG.md "${{ steps.pr_text.outputs.body_file }}"
           # `chore` keeps this bookkeeping commit out of the rendered sections;
           # `docs` would list every release's regeneration in the next release.
           git commit -m "chore(changelog): update for ${tag}"
           git push --force-with-lease origin "${branch}"
-          gh pr create \
-            --base main --head "${branch}" \
-            --title "chore(release): ${tag}" \
-            --body "Automated release prep for **${tag}**. Regenerated CHANGELOG.md via git-changelog. Merging promotes develop -> main; then run the release workflow on main to build, publish, and tag ${tag}."
+
+      - name: Summarise how to open the release PR
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          branch="release/${tag}"
+          body_file="${{ steps.pr_text.outputs.body_file }}"
+          title="chore(release): ${tag}"
+          # Only the title is prefilled via the URL: bodies routinely exceed what a query
+          # string can carry, so the body is copied from the file on the branch instead.
+          encoded_title="$(jq -rn --arg t "${title}" '$t|@uri')"
+          url="${{ github.server_url }}/${{ github.repository }}/compare/main...${branch}?expand=1&title=${encoded_title}"
+
+          {
+            printf '## %s is staged\n\n' "${tag}"
+            printf 'Branch `%s` is pushed. Open the PR manually — a bot-authored PR would not run the `pull_request` checks that gate `main`.\n\n' "${branch}"
+            printf '### [→ Open the release PR](%s)\n\n' "${url}"
+            printf 'Base `main`, head `%s`, title:\n\n```\n%s\n```\n\n' "${branch}" "${title}"
+            printf 'The body below is also committed to `%s` on that branch — copy it in:\n\n' "${body_file}"
+            printf -- '---\n\n'
+            cat "${body_file}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
 
   tag-release:
     name: Tag and create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # CHANGELOG
 
 <!-- insertion marker -->
+<a name="v2.3.0"></a>
+
+## [v2.3.0](https://github.com/swgoh-utils/comlink-python/compare/v2.2.0...v2.3.0) (2026-08-03)
+
+### Features
+
+- **cache:** cache game/localization versions from /metadata with configurable TTL (#117) ([d351759](https://github.com/swgoh-utils/comlink-python/commit/d35175900932c79e5836f383fb6b3ce8dd39f6d9))
+- **cache:** cache game/localization versions from /metadata with configurable TTL ([8cdd771](https://github.com/swgoh-utils/comlink-python/commit/8cdd7719619ac7b83ceb66c069825572e17d018a))
+
+### Bug Fixes
+
+- **hmac:** sign the bytes actually sent so empty-payload POSTs validate ([943fd7f](https://github.com/swgoh-utils/comlink-python/commit/943fd7ff490813a74ad50d7c4e4c35ef76b3e79d))
+- **tests:** call get_game_data with items= instead of the rejected request_segment ([60c19bf](https://github.com/swgoh-utils/comlink-python/commit/60c19bf390818d0610802a1cd3a3ca7f1cb59829))
+- **client:** send clientSpecs key expected by /metadata endpoint ([1909912](https://github.com/swgoh-utils/comlink-python/commit/1909912fc10b1deb822b816b46a0e7577da7e422))
+- **exceptions:** stop logging tracebacks from exception constructors ([f841fa8](https://github.com/swgoh-utils/comlink-python/commit/f841fa88bd64abc6a66326ee0654e367976733ce))
+
+### Docs
+
+- **changelog:** update for v2.2.0 ([7b917de](https://github.com/swgoh-utils/comlink-python/commit/7b917dea5ce146c2cce9bbd90b436ba010f01207))
+
 <a name="v2.2.0"></a>
 
 ## [v2.2.0](https://github.com/swgoh-utils/comlink-python/compare/v2.1.0...v2.2.0) (2026-07-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # CHANGELOG
 
 <!-- insertion marker -->
+<a name="v2.2.0"></a>
+
+## [v2.2.0](https://github.com/swgoh-utils/comlink-python/compare/v2.1.0...v2.2.0) (2026-07-12)
+
+### Features
+
+- **helpers:** add localization dictionary parsing with sync and async support (#108) ([45dce8a](https://github.com/swgoh-utils/comlink-python/commit/45dce8a5f402ccb192b9598d308dd86a703ea43b))
+
+### Bug Fixes
+
+- **tests:** switch HMAC rejection tests from GET to POST endpoint (#89) ([75feb67](https://github.com/swgoh-utils/comlink-python/commit/75feb6701648cbaf986624bb90532b8fe24d443a))
+- **helpers:** ensure arena payout time adjusts correctly when shifted to past ([c9e3f59](https://github.com/swgoh-utils/comlink-python/commit/c9e3f59b91a51137867f766f448d7deda07e90b0))
+- **helpers:** handle multi-day offsets in get_arena_payout ([e8a6e05](https://github.com/swgoh-utils/comlink-python/commit/e8a6e05d997559c23734dda5fee2c44cd172d2e8))
+
+<a name="v2.1.0"></a>
+
+## [v2.1.0](https://github.com/swgoh-utils/comlink-python/compare/v2.0.7...v2.1.0) (2026-06-03)
+
+### Bug Fixes
+
+- **examples): update string quoting and rename params for localization bundle calls docs(helpers): document parse_swgoh_string and its extended tag grammar chore: add commitlint config and ignore .pythonrc.py fix(helpers:** extend parse_swgoh_string to cover full NGUI tag set (#83) ([1536853](https://github.com/swgoh-utils/comlink-python/commit/15368533fc09cbbf60964d3ca5044fc9e8c91499))
+
+<a name="v2.0.7"></a>
+
+## [v2.0.7](https://github.com/swgoh-utils/comlink-python/compare/v2.0.6...v2.0.7) (2026-03-30)
+
+### Bug Fixes
+
+- update `sanitize_url` to handle HTTPS URLs without ports, update tests for improved coverage ([577951a](https://github.com/swgoh-utils/comlink-python/commit/577951a6877f47a62c7bf062399fcca6611c9caf))
+
 
 ## [v2.0.6](https://github.com/swgoh-utils/comlink-python/releases/tag/v2.0.6) - 2026-03-29
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ Constructor parameters for `SwgohComlink` and `SwgohComlinkAsync`:
 | `port` | `int` | `3000` | Comlink TCP port (used with `host`) |
 | `stats_port` | `int` | `3223` | Stats service TCP port (used with `host`) |
 | `verify_ssl` | `bool` | `True` | Enable TLS certificate verification |
+| `version_cache_ttl` | `float` | `3600` | Seconds to cache game/localization versions from `/metadata` (see below) |
+
+### Version caching
+
+Calls to `/data` and `/localization` require the current `latestGamedataVersion` /
+`latestLocalizationBundleVersion` values from the `/metadata` endpoint. When you call
+`get_game_data()`, `get_localization()`, or `get_latest_game_data_version()` without an explicit
+version, the client fetches these values once and caches them on the instance for
+`version_cache_ttl` seconds (default: 1 hour), instead of making a fresh `/metadata` request every
+time.
+
+- Pass `version_cache_ttl=0` to disable caching (the pre-v2.3 behavior), or `math.inf` to cache
+  for the client's lifetime.
+- Explicit `version=` / `localization_id=` arguments always bypass the cache.
+- Call `invalidate_version_cache()` or `get_latest_game_data_version(refresh=True)` to force a
+  re-fetch, e.g. right after a game update lands.
+- A successful `get_game_metadata()` call also refreshes the cache opportunistically.
 
 ## Available Methods
 
@@ -234,7 +251,8 @@ Methods available on both `SwgohComlink` and `SwgohComlinkAsync` (async methods 
 | `get_leaderboard(leaderboard_type, league, division, ...)` | Get GAC leaderboard data |
 | `get_guild_leaderboard(leaderboard_id, count, enums)` | Get guild leaderboard data |
 | `get_unit_stats(request_payload, flags, language)` | Calculate unit stats via swgoh-stats |
-| `get_latest_game_data_version()` | Get latest game data and language versions |
+| `get_latest_game_data_version(refresh)` | Get latest game data and language versions (cached) |
+| `invalidate_version_cache()` | Discard cached versions so the next lookup re-fetches `/metadata` |
 | `get_name_spaces(only_compatible, enums)` | Get available namespaces |
 | `get_segmented_content(content_name_space, accept_language, enums)` | Retrieve segmented content |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,9 @@ in-place = true
 output = "CHANGELOG.md"
 marker-line = "<!-- insertion marker -->"
 bump = "auto"
+# The angular convention renders only feat/fix/revert/refactor/perf by default.
+# Listing them explicitly is what lets `docs` join them.
+sections = ["feat", "fix", "revert", "refactor", "perf", "docs"]
 
 # ── Coverage ─────────────────────────────────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Existing violations to address incrementally — do not add new suppressions
 "src/swgoh_comlink/__init__.py" = ["UP036"]   # outdated version block (sys.exit check)
-"src/swgoh_comlink/exceptions.py" = ["B904"]  # raise-without-from (tracked in issue backlog)
 "src/swgoh_comlink/helpers/*.py" = ["B007", "B904", "SIM102"]  # existing patterns to clean up
 
 [tool.ruff.lint.isort]

--- a/src/swgoh_comlink/_base.py
+++ b/src/swgoh_comlink/_base.py
@@ -194,7 +194,13 @@ class SwgohComlinkBase:
             hmac_obj.update(f"/{endpoint}".encode())
             # json dumps separators needed for compact string formatting required for compatibility with
             # comlink since it is written with javascript as the primary object model
-            if payload:
+            #
+            # The digest has to cover exactly the bytes that go on the wire. A POST sends
+            # `json=payload`, so an empty dict is transmitted as `{}` — testing truthiness
+            # here hashed `""` instead and every empty-payload signed POST (get_game_metadata
+            # with no client_specs) was rejected with HTTP 403 HMACValidationError. Only a
+            # bodiless request (GET, payload=None) hashes the empty string.
+            if payload is not None:
                 payload_string = dumps(payload, separators=(",", ":"))
             else:
                 payload_string = dumps("")

--- a/src/swgoh_comlink/_base.py
+++ b/src/swgoh_comlink/_base.py
@@ -11,22 +11,56 @@ import hmac
 import os
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from json import dumps
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from typing_extensions import Self
 
-from .exceptions import SwgohComlinkValueError
+from .exceptions import SwgohComlinkException, SwgohComlinkValueError
 from .helpers import Constants, DataItems
 
-__all__ = ["SwgohComlinkBase", "param_alias", "DEFAULT_TIMEOUT", "GAME_DATA_TIMEOUT"]
+__all__ = [
+    "SwgohComlinkBase",
+    "param_alias",
+    "DEFAULT_TIMEOUT",
+    "GAME_DATA_TIMEOUT",
+    "DEFAULT_VERSION_CACHE_TTL",
+]
 
 # Keys whose values must be masked in logs, repr, and debug output.
 _SENSITIVE_KEYS = frozenset({"secret_key", "access_key"})
 
 DEFAULT_TIMEOUT: float = 120.0
 GAME_DATA_TIMEOUT: float = 300.0
+DEFAULT_VERSION_CACHE_TTL: float = 3600.0
+
+# Indirection over the monotonic clock so tests can control cache expiry.
+_now: Callable[[], float] = time.monotonic
+
+
+@dataclass(frozen=True)
+class _CachedVersions:
+    """Game data and localization bundle versions cached from a /metadata response.
+
+    Fields are optional because mocked or unusual /metadata responses may omit
+    either key; accessors raise only when the missing value is actually needed.
+    """
+
+    game: str | None
+    language: str | None
+    expires_at: float
+
+    def require_game(self) -> str:
+        if self.game is None:
+            raise SwgohComlinkException("'latestGamedataVersion' was missing from the /metadata response.")
+        return self.game
+
+    def require_language(self) -> str:
+        if self.language is None:
+            raise SwgohComlinkException("'latestLocalizationBundleVersion' was missing from the /metadata response.")
+        return self.language
 
 
 def param_alias(param: str, alias: str) -> Callable[..., Any]:
@@ -110,6 +144,7 @@ class SwgohComlinkBase:
         port: int = 3000,
         stats_port: int = 3223,
         verify_ssl: bool = True,
+        version_cache_ttl: float = DEFAULT_VERSION_CACHE_TTL,
     ):
         from swgoh_comlink import version
 
@@ -118,6 +153,11 @@ class SwgohComlinkBase:
         self.stats_url_base = sanitize_url(stats_url)
         self.hmac = False
         self.verify_ssl = verify_ssl
+        # NaN fails the >= comparison, so it is rejected here along with negatives.
+        if not version_cache_ttl >= 0:
+            raise SwgohComlinkValueError("version_cache_ttl must be a non-negative number of seconds.")
+        self.version_cache_ttl = version_cache_ttl
+        self._version_cache: _CachedVersions | None = None
 
         # host and port parameters override defaults
         if host:
@@ -165,6 +205,33 @@ class SwgohComlinkBase:
             hmac_digest = hmac_obj.hexdigest()
             req_headers["Authorization"] = f"HMAC-SHA256 Credential={self.access_key},Signature={hmac_digest}"
         return req_headers
+
+    # ── Version cache ────────────────────────────────────────────────────
+
+    def invalidate_version_cache(self) -> None:
+        """Discard the cached game/localization versions so the next lookup re-fetches /metadata."""
+        self._version_cache = None
+
+    def _cached_versions(self) -> _CachedVersions | None:
+        """Return the cached version entry when caching is enabled and the entry is fresh."""
+        cached = self._version_cache
+        if cached is None or _now() >= cached.expires_at:
+            return None
+        return cached
+
+    def _store_versions(self, game: str | None, language: str | None) -> _CachedVersions:
+        """Build a version entry from *game* and *language* and cache it when caching applies."""
+        entry = _CachedVersions(game=game, language=language, expires_at=_now() + self.version_cache_ttl)
+        if self.version_cache_ttl > 0 and (game is not None or language is not None):
+            self._version_cache = entry
+        return entry
+
+    @staticmethod
+    def _versions_from_metadata(metadata: dict[str, Any]) -> tuple[str | None, str | None]:
+        """Extract the (game, language) version strings from a /metadata response, if present."""
+        game = metadata.get("latestGamedataVersion")
+        language = metadata.get("latestLocalizationBundleVersion")
+        return str(game) if game else None, str(language) if language else None
 
     # ── Static payload builders ──────────────────────────────────────────
 

--- a/src/swgoh_comlink/exceptions.py
+++ b/src/swgoh_comlink/exceptions.py
@@ -5,18 +5,9 @@ Custom exceptions for swgoh_comlink
 
 from __future__ import annotations
 
-import logging
-
-logger = logging.getLogger(__name__)
-
 
 class SwgohComlinkException(Exception):
     """Base class for exceptions in this module."""
-
-    def __init__(self, message: str | Exception) -> None:
-        super().__init__(message)
-        # Log at error level; callers are responsible for traceback context
-        logger.exception(f"SwgohComlinkException: {message}")
 
 
 class SwgohComlinkValueError(SwgohComlinkException, ValueError):

--- a/src/swgoh_comlink/swgoh_comlink.py
+++ b/src/swgoh_comlink/swgoh_comlink.py
@@ -5,6 +5,7 @@ Synchronous Python 3 interface for swgoh-comlink.
 
 from __future__ import annotations
 
+import threading
 from json import loads
 from typing import Any, cast
 
@@ -14,6 +15,7 @@ from ._base import (
     DEFAULT_TIMEOUT,
     GAME_DATA_TIMEOUT,
     SwgohComlinkBase,
+    _CachedVersions,
     param_alias,
 )
 from .exceptions import SwgohComlinkException, SwgohComlinkValueError
@@ -38,6 +40,8 @@ class SwgohComlink(SwgohComlinkBase):
         port (int): TCP port number where the swgoh-comlink service is running [Default: 3000]
         stats_port (int): TCP port number of where the comlink-stats service is running [Default: 3223]
         verify_ssl (bool): Whether to verify TLS certificates. [Default: True]
+        version_cache_ttl (float): Seconds to cache the game/localization versions fetched from
+            /metadata. 0 disables caching; ``math.inf`` caches for the client lifetime. [Default: 3600]
 
     Notes:
         If the 'host' and 'port' parameters are provided, the 'url' and 'stats_url' parameters are ignored.
@@ -58,6 +62,7 @@ class SwgohComlink(SwgohComlinkBase):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+        self._version_lock = threading.Lock()
         self.client = httpx.Client(
             base_url=self.url_base,
             headers={"Content-Type": "application/json"},
@@ -140,9 +145,28 @@ class SwgohComlink(SwgohComlinkBase):
         """
         return self._request(method="POST", endpoint=endpoint, payload=payload, stats=stats, timeout=timeout)
 
+    def _get_versions(self, refresh: bool = False) -> _CachedVersions:
+        """Return the current game/localization versions, served from the instance cache.
+
+        Args:
+            refresh: When True, bypass the cache and fetch fresh values from /metadata.
+        """
+        if not refresh:
+            cached = self._cached_versions()
+            if cached is not None:
+                return cached
+        with self._version_lock:
+            # Double-check inside the lock so concurrent cold-cache callers
+            # coalesce into a single /metadata request.
+            if not refresh:
+                cached = self._cached_versions()
+                if cached is not None:
+                    return cached
+            metadata = self.get_game_metadata()
+            return self._store_versions(*self._versions_from_metadata(metadata))
+
     def _get_game_version(self) -> str:
-        md = self.get_game_metadata()
-        return str(md["latestGamedataVersion"])
+        return self._get_versions().require_game()
 
     # ── Public API methods ───────────────────────────────────────────────
 
@@ -253,8 +277,7 @@ class SwgohComlink(SwgohComlinkBase):
             A dictionary containing the localization data.
         """
         if not localization_id:
-            current_game_version = self.get_latest_game_data_version()
-            localization_id = current_game_version["language"]
+            localization_id = self._get_versions().require_language()
 
         if locale:
             assert localization_id is not None
@@ -283,7 +306,14 @@ class SwgohComlink(SwgohComlinkBase):
             payload: dict[str, Any] = {"payload": {"clientSpecs": client_specs}, "enums": enums}
         else:
             payload = {}
-        return cast(dict[str, Any], self._post(endpoint="metadata", payload=payload))
+        metadata = cast(dict[str, Any], self._post(endpoint="metadata", payload=payload))
+        # Opportunistically refresh the version cache; enums=True responses are
+        # skipped since their values may be translated.
+        if not enums and isinstance(metadata, dict):
+            game, language = self._versions_from_metadata(metadata)
+            if game is not None and language is not None:
+                self._store_versions(game, language)
+        return metadata
 
     # alias for non PEP usage of direct endpoint calls
     getGameMetaData = get_game_metadata
@@ -501,17 +531,19 @@ class SwgohComlink(SwgohComlinkBase):
 
     # ── Helper methods ───────────────────────────────────────────────────
 
-    def get_latest_game_data_version(self) -> dict[str, Any]:
+    def get_latest_game_data_version(self, refresh: bool = False) -> dict[str, Any]:
         """Get the latest game data and language bundle versions.
+
+        Results are served from the instance version cache (see ``version_cache_ttl``).
+
+        Args:
+            refresh: When True, bypass the cache and fetch fresh values from /metadata.
 
         Returns:
             Dictionary with 'game' and 'language' version strings.
         """
-        current_metadata = self.get_metadata()
-        return {
-            "game": current_metadata["latestGamedataVersion"],
-            "language": current_metadata["latestLocalizationBundleVersion"],
-        }
+        versions = self._get_versions(refresh=refresh)
+        return {"game": versions.require_game(), "language": versions.require_language()}
 
     # alias for shorthand call
     getVersion = get_latest_game_data_version

--- a/src/swgoh_comlink/swgoh_comlink.py
+++ b/src/swgoh_comlink/swgoh_comlink.py
@@ -280,7 +280,7 @@ class SwgohComlink(SwgohComlinkBase):
             A dictionary containing the game metadata.
         """
         if client_specs:
-            payload: dict[str, Any] = {"payload": {"client_specs": client_specs}, "enums": enums}
+            payload: dict[str, Any] = {"payload": {"clientSpecs": client_specs}, "enums": enums}
         else:
             payload = {}
         return cast(dict[str, Any], self._post(endpoint="metadata", payload=payload))

--- a/src/swgoh_comlink/swgoh_comlink_async.py
+++ b/src/swgoh_comlink/swgoh_comlink_async.py
@@ -278,7 +278,7 @@ class SwgohComlinkAsync(SwgohComlinkBase):
             A dictionary containing the game metadata.
         """
         if client_specs:
-            payload: dict[str, Any] = {"payload": {"client_specs": client_specs}, "enums": enums}
+            payload: dict[str, Any] = {"payload": {"clientSpecs": client_specs}, "enums": enums}
         else:
             payload = {}
         return cast(dict[str, Any], await self._post(endpoint="metadata", payload=payload))

--- a/src/swgoh_comlink/swgoh_comlink_async.py
+++ b/src/swgoh_comlink/swgoh_comlink_async.py
@@ -5,6 +5,7 @@ Asynchronous Python 3 interface for swgoh-comlink.
 
 from __future__ import annotations
 
+import asyncio
 from json import loads
 from typing import Any, cast
 
@@ -14,6 +15,7 @@ from ._base import (
     DEFAULT_TIMEOUT,
     GAME_DATA_TIMEOUT,
     SwgohComlinkBase,
+    _CachedVersions,
     param_alias,
 )
 from .exceptions import SwgohComlinkException, SwgohComlinkValueError
@@ -38,6 +40,8 @@ class SwgohComlinkAsync(SwgohComlinkBase):
         port (int): TCP port number where the swgoh-comlink service is running [Default: 3000]
         stats_port (int): TCP port number of where the comlink-stats service is running [Default: 3223]
         verify_ssl (bool): Whether to verify TLS certificates. [Default: True]
+        version_cache_ttl (float): Seconds to cache the game/localization versions fetched from
+            /metadata. 0 disables caching; ``math.inf`` caches for the client lifetime. [Default: 3600]
 
     Notes:
         If the 'host' and 'port' parameters are provided, the 'url' and 'stats_url' parameters are ignored.
@@ -53,6 +57,7 @@ class SwgohComlinkAsync(SwgohComlinkBase):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+        self._version_lock = asyncio.Lock()
         connection_limits = httpx.Limits(keepalive_expiry=None)
         self.client = httpx.AsyncClient(
             base_url=self.url_base,
@@ -136,9 +141,28 @@ class SwgohComlinkAsync(SwgohComlinkBase):
         """
         return await self._request(method="POST", endpoint=endpoint, payload=payload, stats=stats, timeout=timeout)
 
+    async def _get_versions(self, refresh: bool = False) -> _CachedVersions:
+        """Return the current game/localization versions, served from the instance cache.
+
+        Args:
+            refresh: When True, bypass the cache and fetch fresh values from /metadata.
+        """
+        if not refresh:
+            cached = self._cached_versions()
+            if cached is not None:
+                return cached
+        async with self._version_lock:
+            # Double-check inside the lock so concurrent cold-cache callers
+            # coalesce into a single /metadata request.
+            if not refresh:
+                cached = self._cached_versions()
+                if cached is not None:
+                    return cached
+            metadata = await self.get_game_metadata()
+            return self._store_versions(*self._versions_from_metadata(metadata))
+
     async def _get_game_version(self) -> str:
-        md = await self.get_game_metadata()
-        return str(md["latestGamedataVersion"])
+        return (await self._get_versions()).require_game()
 
     # ── Public API methods ───────────────────────────────────────────────
 
@@ -249,8 +273,7 @@ class SwgohComlinkAsync(SwgohComlinkBase):
             A dictionary containing the localization data.
         """
         if not localization_id:
-            current_game_version = await self.get_latest_game_data_version()
-            localization_id = current_game_version["language"]
+            localization_id = (await self._get_versions()).require_language()
 
         if locale:
             assert localization_id is not None
@@ -281,7 +304,14 @@ class SwgohComlinkAsync(SwgohComlinkBase):
             payload: dict[str, Any] = {"payload": {"clientSpecs": client_specs}, "enums": enums}
         else:
             payload = {}
-        return cast(dict[str, Any], await self._post(endpoint="metadata", payload=payload))
+        metadata = cast(dict[str, Any], await self._post(endpoint="metadata", payload=payload))
+        # Opportunistically refresh the version cache; enums=True responses are
+        # skipped since their values may be translated.
+        if not enums and isinstance(metadata, dict):
+            game, language = self._versions_from_metadata(metadata)
+            if game is not None and language is not None:
+                self._store_versions(game, language)
+        return metadata
 
     # alias for non PEP usage of direct endpoint calls
     getGameMetaData = get_game_metadata
@@ -499,17 +529,19 @@ class SwgohComlinkAsync(SwgohComlinkBase):
 
     # ── Helper methods ───────────────────────────────────────────────────
 
-    async def get_latest_game_data_version(self) -> dict[str, Any]:
+    async def get_latest_game_data_version(self, refresh: bool = False) -> dict[str, Any]:
         """Get the latest game data and language bundle versions.
+
+        Results are served from the instance version cache (see ``version_cache_ttl``).
+
+        Args:
+            refresh: When True, bypass the cache and fetch fresh values from /metadata.
 
         Returns:
             Dictionary with 'game' and 'language' version strings.
         """
-        current_metadata = await self.get_metadata()
-        return {
-            "game": current_metadata["latestGamedataVersion"],
-            "language": current_metadata["latestLocalizationBundleVersion"],
-        }
+        versions = await self._get_versions(refresh=refresh)
+        return {"game": versions.require_game(), "language": versions.require_language()}
 
     # alias for shorthand call
     getVersion = get_latest_game_data_version

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -18,28 +18,30 @@ async def test_get_enums(async_comlink):
 
 
 async def test_get_game_metadata(async_comlink):
-    """POST /metadata returns game metadata with version info."""
+    """POST /metadata returns game metadata with a populated version string."""
     result = await async_comlink.get_game_metadata()
     assert isinstance(result, dict)
-    assert "latestGamedataVersion" in result
+    assert result.get("latestGamedataVersion"), "version must be present and non-empty"
 
 
 async def test_get_latest_game_data_version(async_comlink):
-    """Helper returns dict with 'game' and 'language' version strings."""
+    """Helper returns dict with non-empty 'game' and 'language' version strings.
+
+    Asserting the type alone would pass on empty strings, which is the shape a
+    broken version lookup returns.
+    """
     result = await async_comlink.get_latest_game_data_version()
     assert isinstance(result, dict)
-    assert "game" in result
-    assert "language" in result
-    assert isinstance(result["game"], str)
-    assert isinstance(result["language"], str)
+    assert isinstance(result["game"], str) and result["game"], "game version must be non-empty"
+    assert isinstance(result["language"], str) and result["language"], "language version must be non-empty"
 
 
 async def test_get_events(async_comlink):
-    """POST /getEvents returns event data."""
+    """POST /getEvents returns a populated event list."""
     result = await async_comlink.get_events()
     assert isinstance(result, dict)
-    assert "gameEvent" in result
     assert isinstance(result["gameEvent"], list)
+    assert result["gameEvent"], "a live Comlink instance always has scheduled events"
 
 
 async def test_get_player(async_comlink):
@@ -54,11 +56,19 @@ async def test_get_player(async_comlink):
 
 
 async def test_get_player_arena(async_comlink):
-    """POST /playerArena returns arena profile."""
+    """POST /playerArena returns an arena profile with populated squads."""
     result = await async_comlink.get_player_arena(allycode=TEST_ALLYCODE)
     assert isinstance(result, dict)
-    assert "name" in result
-    assert "pvpProfile" in result
+    assert result["name"]
+    assert result["pvpProfile"], "arena profile must list at least one arena tab"
+    assert any(entry.get("squad") for entry in result["pvpProfile"]), "full response includes squad rosters"
+
+
+async def test_get_player_arena_details_only(async_comlink):
+    """player_details_only=True keeps the arena tabs but drops the squad rosters."""
+    result = await async_comlink.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
+    assert result["pvpProfile"], "arena tabs are still returned"
+    assert all(entry.get("squad") is None for entry in result["pvpProfile"]), "squads must be omitted"
 
 
 async def test_get_guilds_by_name(async_comlink):
@@ -84,7 +94,14 @@ async def test_get_game_data_filtered(async_comlink):
 
 
 async def test_async_context_manager():
-    """Async client works correctly as an async context manager."""
+    """Exiting the async context manager closes the underlying HTTP client.
+
+    Closure is the whole point of the context manager, so assert on it — a test
+    that only calls an endpoint inside the block would pass without it.
+    """
     async with SwgohComlinkAsync(url=COMLINK_URL) as client:
+        inner = client.client
+        assert not inner.is_closed
         result = await client.get_enums()
-        assert isinstance(result, dict)
+        assert "CombatType" in result
+    assert inner.is_closed, "exiting the context manager must close the HTTP client"

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -3,6 +3,7 @@
 import pytest
 
 from swgoh_comlink import SwgohComlinkAsync
+from swgoh_comlink.helpers import DataItems
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
@@ -70,8 +71,8 @@ async def test_get_guilds_by_name(async_comlink):
 
 
 async def test_get_game_data_filtered(async_comlink):
-    """POST /data with request_segment=1 returns a non-empty game data subset."""
-    result = await async_comlink.get_game_data(request_segment=1)
+    """POST /data with items=SEGMENT1 returns a non-empty game data subset."""
+    result = await async_comlink.get_game_data(items=DataItems.SEGMENT1)
     assert isinstance(result, dict)
     assert len(result) > 0
 

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -3,10 +3,24 @@
 import pytest
 
 from swgoh_comlink import SwgohComlinkAsync
+from swgoh_comlink.exceptions import SwgohComlinkException
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+# A cold service container in CI cannot complete a /data fetch from the upstream game
+# servers: every form of the request fails with HTTP 400 and the body "Did not receive a
+# response code back from the server, even after a retry." The trailing hint about the
+# parameter being invalid is boilerplate — request_segment, a Segment aggregate, and a
+# single collection value all fail identically, on both 4.4.0 and 4.4.1, while every
+# other endpoint works. Nothing in this library can fix that, so the /data tests are
+# expected to fail there. Non-strict on purpose: they pass against a warm instance, and
+# an XPASS is the signal that upstream has recovered and this marker can come off.
+data_endpoint_unavailable = pytest.mark.xfail(
+    raises=SwgohComlinkException,
+    reason="upstream /data fetch fails on a cold CI service container",
+)
 
 
 async def test_get_enums(async_comlink):
@@ -79,6 +93,7 @@ async def test_get_guilds_by_name(async_comlink):
     assert len(result["guild"]) > 0
 
 
+@data_endpoint_unavailable
 async def test_get_game_data_filtered(async_comlink):
     """POST /data with a single items collection populates that collection and no other.
 

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -3,24 +3,10 @@
 import pytest
 
 from swgoh_comlink import SwgohComlinkAsync
-from swgoh_comlink.exceptions import SwgohComlinkException
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
-
-# A cold service container in CI cannot complete a /data fetch from the upstream game
-# servers: every form of the request fails with HTTP 400 and the body "Did not receive a
-# response code back from the server, even after a retry." The trailing hint about the
-# parameter being invalid is boilerplate — request_segment, a Segment aggregate, and a
-# single collection value all fail identically, on both 4.4.0 and 4.4.1, while every
-# other endpoint works. Nothing in this library can fix that, so the /data tests are
-# expected to fail there. Non-strict on purpose: they pass against a warm instance, and
-# an XPASS is the signal that upstream has recovered and this marker can come off.
-data_endpoint_unavailable = pytest.mark.xfail(
-    raises=SwgohComlinkException,
-    reason="upstream /data fetch fails on a cold CI service container",
-)
 
 
 async def test_get_enums(async_comlink):
@@ -93,7 +79,6 @@ async def test_get_guilds_by_name(async_comlink):
     assert len(result["guild"]) > 0
 
 
-@data_endpoint_unavailable
 async def test_get_game_data_filtered(async_comlink):
     """POST /data with a single items collection populates that collection and no other.
 

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -71,10 +71,16 @@ async def test_get_guilds_by_name(async_comlink):
 
 
 async def test_get_game_data_filtered(async_comlink):
-    """POST /data with items=SEGMENT1 returns a non-empty game data subset."""
+    """POST /data with items=SEGMENT1 populates the SEGMENT1 collections and no others.
+
+    /data always returns the same full set of collection keys regardless of what was
+    requested — the ones not asked for come back empty. So asserting on len(result)
+    would pass even if the filter matched nothing; assert on which keys are populated.
+    """
     result = await async_comlink.get_game_data(items=DataItems.SEGMENT1)
     assert isinstance(result, dict)
-    assert len(result) > 0
+    assert result["equipment"], "requested SEGMENT1 collection should be populated"
+    assert not result["units"], "unrequested SEGMENT3 collection should be empty"
 
 
 async def test_async_context_manager():

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -3,7 +3,6 @@
 import pytest
 
 from swgoh_comlink import SwgohComlinkAsync
-from swgoh_comlink.helpers import DataItems
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
@@ -81,13 +80,19 @@ async def test_get_guilds_by_name(async_comlink):
 
 
 async def test_get_game_data_filtered(async_comlink):
-    """POST /data with items=SEGMENT1 populates the SEGMENT1 collections and no others.
+    """POST /data with the Segment1 items value populates only the Segment1 collections.
 
     /data always returns the same full set of collection keys regardless of what was
     requested — the ones not asked for come back empty. So asserting on len(result)
     would pass even if the filter matched nothing; assert on which keys are populated.
+
+    The items value is read from the server's own GameDataItemsEnum rather than from
+    the client-side DataItems constants. Segment values are aggregate bitmasks, so they
+    shift whenever a collection is added to a segment, and a stale local copy is
+    rejected outright (HTTP 400) by newer Comlink builds.
     """
-    result = await async_comlink.get_game_data(items=DataItems.SEGMENT1)
+    segment1 = (await async_comlink.get_enums())["GameDataItemsEnum"]["Segment1"]
+    result = await async_comlink.get_game_data(items=segment1)
     assert isinstance(result, dict)
     assert result["equipment"], "requested SEGMENT1 collection should be populated"
     assert not result["units"], "unrequested SEGMENT3 collection should be empty"

--- a/tests/integration/test_async_client.py
+++ b/tests/integration/test_async_client.py
@@ -80,22 +80,23 @@ async def test_get_guilds_by_name(async_comlink):
 
 
 async def test_get_game_data_filtered(async_comlink):
-    """POST /data with the Segment1 items value populates only the Segment1 collections.
+    """POST /data with a single items collection populates that collection and no other.
 
     /data always returns the same full set of collection keys regardless of what was
     requested — the ones not asked for come back empty. So asserting on len(result)
     would pass even if the filter matched nothing; assert on which keys are populated.
 
-    The items value is read from the server's own GameDataItemsEnum rather than from
-    the client-side DataItems constants. Segment values are aggregate bitmasks, so they
-    shift whenever a collection is added to a segment, and a stale local copy is
-    rejected outright (HTTP 400) by newer Comlink builds.
+    The value comes from the server's own GameDataItemsEnum rather than the client-side
+    DataItems constants, which are a hand-maintained copy that can drift. A single
+    collection is used rather than a Segment aggregate: it isolates the filter exactly,
+    and it returns in well under a second where an aggregate takes ~10s and has been
+    seen to fail upstream against a cold service container.
     """
-    segment1 = (await async_comlink.get_enums())["GameDataItemsEnum"]["Segment1"]
-    result = await async_comlink.get_game_data(items=segment1)
+    equipment_only = (await async_comlink.get_enums())["GameDataItemsEnum"]["EquipmentDefinitions"]
+    result = await async_comlink.get_game_data(items=equipment_only)
     assert isinstance(result, dict)
-    assert result["equipment"], "requested SEGMENT1 collection should be populated"
-    assert not result["units"], "unrequested SEGMENT3 collection should be empty"
+    assert result["equipment"], "the requested collection should be populated"
+    assert not result["units"], "every unrequested collection should be empty"
 
 
 async def test_async_context_manager():

--- a/tests/integration/test_hmac.py
+++ b/tests/integration/test_hmac.py
@@ -24,24 +24,34 @@ hmac_configured = pytest.mark.skipif(
     reason="HMAC secrets not configured",
 )
 
+# SwgohComlinkException wraps transport failures as well as HTTP status errors, so a
+# bare `pytest.raises(SwgohComlinkException)` is satisfied by "connection refused" —
+# the rejection tests would pass if the HMAC service never came up. Matching the HTTP
+# status text asserts the server actually saw the request and turned it away.
+REJECTED = r"HTTP 4\d{2}"
+
 
 # ── Sync: valid HMAC ────────────────────────────────────────────────────
 
 
 @hmac_configured
 def test_hmac_sync_request_succeeds(comlink_hmac):
-    """Sync client with correct HMAC keys can access the protected endpoint."""
-    result = comlink_hmac.get_enums()
+    """Sync client with correct HMAC keys can reach a signed POST endpoint.
+
+    Uses `metadata` rather than `enums`: HMAC is only enforced on POST, so a GET
+    endpoint would pass whether or not request signing works at all.
+    """
+    result = comlink_hmac.get_game_metadata()
     assert isinstance(result, dict)
-    assert "CombatType" in result
+    assert result.get("latestGamedataVersion"), "signed POST must return real metadata"
 
 
 @hmac_configured
 def test_hmac_sync_player_request_succeeds(comlink_hmac):
     """Sync HMAC client can fetch a player profile from the protected endpoint."""
-    result = comlink_hmac.get_player(allycode=314927874)
+    result = comlink_hmac.get_player(allycode=TEST_ALLYCODE)
     assert isinstance(result, dict)
-    assert "name" in result
+    assert result["name"]
 
 
 # ── Sync: invalid HMAC ──────────────────────────────────────────────────
@@ -55,7 +65,7 @@ def test_hmac_no_key_rejected():
     only enforces HMAC on POST; GET endpoints like `/enums` are
     unauthenticated.
     """
-    with SwgohComlink(url=COMLINK_HMAC_URL) as client, pytest.raises(SwgohComlinkException):
+    with SwgohComlink(url=COMLINK_HMAC_URL) as client, pytest.raises(SwgohComlinkException, match=REJECTED):
         client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 
@@ -73,7 +83,7 @@ def test_hmac_wrong_key_rejected():
             access_key=HMAC_ACCESS_KEY,
             secret_key="wrong_secret_key",
         ) as client,
-        pytest.raises(SwgohComlinkException),
+        pytest.raises(SwgohComlinkException, match=REJECTED),
     ):
         client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
@@ -84,19 +94,23 @@ def test_hmac_wrong_key_rejected():
 @hmac_configured
 @pytest.mark.asyncio
 async def test_hmac_async_request_succeeds(async_comlink_hmac):
-    """Async client with correct HMAC keys can access the protected endpoint."""
-    result = await async_comlink_hmac.get_enums()
+    """Async client with correct HMAC keys can reach a signed POST endpoint.
+
+    Uses `metadata` rather than `enums`: HMAC is only enforced on POST, so a GET
+    endpoint would pass whether or not request signing works at all.
+    """
+    result = await async_comlink_hmac.get_game_metadata()
     assert isinstance(result, dict)
-    assert "CombatType" in result
+    assert result.get("latestGamedataVersion"), "signed POST must return real metadata"
 
 
 @hmac_configured
 @pytest.mark.asyncio
 async def test_hmac_async_player_request_succeeds(async_comlink_hmac):
     """Async HMAC client can fetch a player profile from the protected endpoint."""
-    result = await async_comlink_hmac.get_player(allycode=314927874)
+    result = await async_comlink_hmac.get_player(allycode=TEST_ALLYCODE)
     assert isinstance(result, dict)
-    assert "name" in result
+    assert result["name"]
 
 
 # ── Async: invalid HMAC ─────────────────────────────────────────────────
@@ -112,7 +126,7 @@ async def test_hmac_no_key_async_rejected():
     unauthenticated.
     """
     async with SwgohComlinkAsync(url=COMLINK_HMAC_URL) as client:
-        with pytest.raises(SwgohComlinkException):
+        with pytest.raises(SwgohComlinkException, match=REJECTED):
             await client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 
@@ -130,7 +144,7 @@ async def test_hmac_wrong_key_async_rejected():
         access_key=HMAC_ACCESS_KEY,
         secret_key="wrong_secret_key",
     ) as client:
-        with pytest.raises(SwgohComlinkException):
+        with pytest.raises(SwgohComlinkException, match=REJECTED):
             await client.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
 
 

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -3,10 +3,24 @@
 import pytest
 
 from swgoh_comlink import SwgohComlink
+from swgoh_comlink.exceptions import SwgohComlinkException
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
 pytestmark = pytest.mark.integration
+
+# A cold service container in CI cannot complete a /data fetch from the upstream game
+# servers: every form of the request fails with HTTP 400 and the body "Did not receive a
+# response code back from the server, even after a retry." The trailing hint about the
+# parameter being invalid is boilerplate — request_segment, a Segment aggregate, and a
+# single collection value all fail identically, on both 4.4.0 and 4.4.1, while every
+# other endpoint works. Nothing in this library can fix that, so the /data tests are
+# expected to fail there. Non-strict on purpose: they pass against a warm instance, and
+# an XPASS is the signal that upstream has recovered and this marker can come off.
+data_endpoint_unavailable = pytest.mark.xfail(
+    raises=SwgohComlinkException,
+    reason="upstream /data fetch fails on a cold CI service container",
+)
 
 
 def test_get_enums(comlink):
@@ -79,6 +93,7 @@ def test_get_guilds_by_name(comlink):
     assert len(result["guild"]) > 0
 
 
+@data_endpoint_unavailable
 def test_get_game_data_filtered(comlink):
     """POST /data with a single items collection populates that collection and no other.
 

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -3,6 +3,7 @@
 import pytest
 
 from swgoh_comlink import SwgohComlink
+from swgoh_comlink.helpers import DataItems
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
@@ -70,8 +71,8 @@ def test_get_guilds_by_name(comlink):
 
 
 def test_get_game_data_filtered(comlink):
-    """POST /data with request_segment=1 returns a non-empty game data subset."""
-    result = comlink.get_game_data(request_segment=1)
+    """POST /data with items=SEGMENT1 returns a non-empty game data subset."""
+    result = comlink.get_game_data(items=DataItems.SEGMENT1)
     assert isinstance(result, dict)
     assert len(result) > 0
 

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -3,24 +3,10 @@
 import pytest
 
 from swgoh_comlink import SwgohComlink
-from swgoh_comlink.exceptions import SwgohComlinkException
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
 pytestmark = pytest.mark.integration
-
-# A cold service container in CI cannot complete a /data fetch from the upstream game
-# servers: every form of the request fails with HTTP 400 and the body "Did not receive a
-# response code back from the server, even after a retry." The trailing hint about the
-# parameter being invalid is boilerplate — request_segment, a Segment aggregate, and a
-# single collection value all fail identically, on both 4.4.0 and 4.4.1, while every
-# other endpoint works. Nothing in this library can fix that, so the /data tests are
-# expected to fail there. Non-strict on purpose: they pass against a warm instance, and
-# an XPASS is the signal that upstream has recovered and this marker can come off.
-data_endpoint_unavailable = pytest.mark.xfail(
-    raises=SwgohComlinkException,
-    reason="upstream /data fetch fails on a cold CI service container",
-)
 
 
 def test_get_enums(comlink):
@@ -93,7 +79,6 @@ def test_get_guilds_by_name(comlink):
     assert len(result["guild"]) > 0
 
 
-@data_endpoint_unavailable
 def test_get_game_data_filtered(comlink):
     """POST /data with a single items collection populates that collection and no other.
 

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -18,28 +18,30 @@ def test_get_enums(comlink):
 
 
 def test_get_game_metadata(comlink):
-    """POST /metadata returns game metadata with version info."""
+    """POST /metadata returns game metadata with a populated version string."""
     result = comlink.get_game_metadata()
     assert isinstance(result, dict)
-    assert "latestGamedataVersion" in result
+    assert result.get("latestGamedataVersion"), "version must be present and non-empty"
 
 
 def test_get_latest_game_data_version(comlink):
-    """Helper returns dict with 'game' and 'language' version strings."""
+    """Helper returns dict with non-empty 'game' and 'language' version strings.
+
+    Asserting the type alone would pass on empty strings, which is the shape a
+    broken version lookup returns.
+    """
     result = comlink.get_latest_game_data_version()
     assert isinstance(result, dict)
-    assert "game" in result
-    assert "language" in result
-    assert isinstance(result["game"], str)
-    assert isinstance(result["language"], str)
+    assert isinstance(result["game"], str) and result["game"], "game version must be non-empty"
+    assert isinstance(result["language"], str) and result["language"], "language version must be non-empty"
 
 
 def test_get_events(comlink):
-    """POST /getEvents returns event data."""
+    """POST /getEvents returns a populated event list."""
     result = comlink.get_events()
     assert isinstance(result, dict)
-    assert "gameEvent" in result
     assert isinstance(result["gameEvent"], list)
+    assert result["gameEvent"], "a live Comlink instance always has scheduled events"
 
 
 def test_get_player(comlink):
@@ -54,11 +56,19 @@ def test_get_player(comlink):
 
 
 def test_get_player_arena(comlink):
-    """POST /playerArena returns arena profile."""
+    """POST /playerArena returns an arena profile with populated squads."""
     result = comlink.get_player_arena(allycode=TEST_ALLYCODE)
     assert isinstance(result, dict)
-    assert "name" in result
-    assert "pvpProfile" in result
+    assert result["name"]
+    assert result["pvpProfile"], "arena profile must list at least one arena tab"
+    assert any(entry.get("squad") for entry in result["pvpProfile"]), "full response includes squad rosters"
+
+
+def test_get_player_arena_details_only(comlink):
+    """player_details_only=True keeps the arena tabs but drops the squad rosters."""
+    result = comlink.get_player_arena(allycode=TEST_ALLYCODE, player_details_only=True)
+    assert result["pvpProfile"], "arena tabs are still returned"
+    assert all(entry.get("squad") is None for entry in result["pvpProfile"]), "squads must be omitted"
 
 
 def test_get_guilds_by_name(comlink):
@@ -84,7 +94,14 @@ def test_get_game_data_filtered(comlink):
 
 
 def test_context_manager():
-    """Client works correctly as a context manager."""
+    """Exiting the context manager closes the underlying HTTP client.
+
+    Closure is the whole point of the context manager, so assert on it — a test
+    that only calls an endpoint inside the block would pass without it.
+    """
     with SwgohComlink(url=COMLINK_URL) as client:
+        inner = client.client
+        assert not inner.is_closed
         result = client.get_enums()
-        assert isinstance(result, dict)
+        assert "CombatType" in result
+    assert inner.is_closed, "exiting the context manager must close the HTTP client"

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -3,7 +3,6 @@
 import pytest
 
 from swgoh_comlink import SwgohComlink
-from swgoh_comlink.helpers import DataItems
 
 from .conftest import COMLINK_URL, TEST_ALLYCODE
 
@@ -81,13 +80,19 @@ def test_get_guilds_by_name(comlink):
 
 
 def test_get_game_data_filtered(comlink):
-    """POST /data with items=SEGMENT1 populates the SEGMENT1 collections and no others.
+    """POST /data with the Segment1 items value populates only the Segment1 collections.
 
     /data always returns the same full set of collection keys regardless of what was
     requested — the ones not asked for come back empty. So asserting on len(result)
     would pass even if the filter matched nothing; assert on which keys are populated.
+
+    The items value is read from the server's own GameDataItemsEnum rather than from
+    the client-side DataItems constants. Segment values are aggregate bitmasks, so they
+    shift whenever a collection is added to a segment, and a stale local copy is
+    rejected outright (HTTP 400) by newer Comlink builds.
     """
-    result = comlink.get_game_data(items=DataItems.SEGMENT1)
+    segment1 = comlink.get_enums()["GameDataItemsEnum"]["Segment1"]
+    result = comlink.get_game_data(items=segment1)
     assert isinstance(result, dict)
     assert result["equipment"], "requested SEGMENT1 collection should be populated"
     assert not result["units"], "unrequested SEGMENT3 collection should be empty"

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -80,22 +80,23 @@ def test_get_guilds_by_name(comlink):
 
 
 def test_get_game_data_filtered(comlink):
-    """POST /data with the Segment1 items value populates only the Segment1 collections.
+    """POST /data with a single items collection populates that collection and no other.
 
     /data always returns the same full set of collection keys regardless of what was
     requested — the ones not asked for come back empty. So asserting on len(result)
     would pass even if the filter matched nothing; assert on which keys are populated.
 
-    The items value is read from the server's own GameDataItemsEnum rather than from
-    the client-side DataItems constants. Segment values are aggregate bitmasks, so they
-    shift whenever a collection is added to a segment, and a stale local copy is
-    rejected outright (HTTP 400) by newer Comlink builds.
+    The value comes from the server's own GameDataItemsEnum rather than the client-side
+    DataItems constants, which are a hand-maintained copy that can drift. A single
+    collection is used rather than a Segment aggregate: it isolates the filter exactly,
+    and it returns in well under a second where an aggregate takes ~10s and has been
+    seen to fail upstream against a cold service container.
     """
-    segment1 = comlink.get_enums()["GameDataItemsEnum"]["Segment1"]
-    result = comlink.get_game_data(items=segment1)
+    equipment_only = comlink.get_enums()["GameDataItemsEnum"]["EquipmentDefinitions"]
+    result = comlink.get_game_data(items=equipment_only)
     assert isinstance(result, dict)
-    assert result["equipment"], "requested SEGMENT1 collection should be populated"
-    assert not result["units"], "unrequested SEGMENT3 collection should be empty"
+    assert result["equipment"], "the requested collection should be populated"
+    assert not result["units"], "every unrequested collection should be empty"
 
 
 def test_context_manager():

--- a/tests/integration/test_sync_client.py
+++ b/tests/integration/test_sync_client.py
@@ -71,10 +71,16 @@ def test_get_guilds_by_name(comlink):
 
 
 def test_get_game_data_filtered(comlink):
-    """POST /data with items=SEGMENT1 returns a non-empty game data subset."""
+    """POST /data with items=SEGMENT1 populates the SEGMENT1 collections and no others.
+
+    /data always returns the same full set of collection keys regardless of what was
+    requested — the ones not asked for come back empty. So asserting on len(result)
+    would pass even if the filter matched nothing; assert on which keys are populated.
+    """
     result = comlink.get_game_data(items=DataItems.SEGMENT1)
     assert isinstance(result, dict)
-    assert len(result) > 0
+    assert result["equipment"], "requested SEGMENT1 collection should be populated"
+    assert not result["units"], "unrequested SEGMENT3 collection should be empty"
 
 
 def test_context_manager():

--- a/tests/test_get_metadata.py
+++ b/tests/test_get_metadata.py
@@ -32,7 +32,7 @@ class TestGetMetadata(TestCase):
 
         call_kwargs = mock_post.call_args
         payload = call_kwargs.kwargs.get("payload") or call_kwargs[1].get("payload")
-        self.assertIn("client_specs", payload["payload"])
+        self.assertIn("clientSpecs", payload["payload"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_async_client_mocked.py
+++ b/tests/unit/test_async_client_mocked.py
@@ -257,7 +257,7 @@ async def test_get_game_metadata_with_client_specs(httpx_mock: HTTPXMock):
     await client.get_game_metadata(client_specs=specs, enums=True)
 
     body = json.loads(httpx_mock.get_request().content)
-    assert body == {"payload": {"client_specs": specs}, "enums": True}
+    assert body == {"payload": {"clientSpecs": specs}, "enums": True}
     await client.aclose()
 
 

--- a/tests/unit/test_client_request_mocked.py
+++ b/tests/unit/test_client_request_mocked.py
@@ -230,7 +230,7 @@ def test_get_game_metadata_with_client_specs(httpx_mock: HTTPXMock):
     client.get_game_metadata(client_specs=specs, enums=True)
 
     body = json.loads(httpx_mock.get_request().content)
-    assert body == {"payload": {"client_specs": specs}, "enums": True}
+    assert body == {"payload": {"clientSpecs": specs}, "enums": True}
 
 
 # ── Player Arena ─────────────────────────────────────────────────────────

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,36 @@
+"""Tests for the swgoh_comlink exception hierarchy."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from swgoh_comlink.exceptions import (
+    SwgohComlinkException,
+    SwgohComlinkTypeError,
+    SwgohComlinkValueError,
+)
+
+
+def test_hierarchy():
+    assert issubclass(SwgohComlinkValueError, SwgohComlinkException)
+    assert issubclass(SwgohComlinkValueError, ValueError)
+    assert issubclass(SwgohComlinkTypeError, SwgohComlinkException)
+    assert issubclass(SwgohComlinkTypeError, TypeError)
+
+
+def test_constructing_exceptions_does_not_log(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level(logging.DEBUG):
+        SwgohComlinkException("boom")
+        try:
+            raise SwgohComlinkValueError("bad value")
+        except SwgohComlinkValueError:
+            pass
+
+    assert caplog.records == []
+
+
+def test_exception_message_preserved():
+    exc = SwgohComlinkException("HTTP 500: oops")
+    assert str(exc) == "HTTP 500: oops"

--- a/tests/unit/test_version_cache.py
+++ b/tests/unit/test_version_cache.py
@@ -1,0 +1,214 @@
+"""Tests for the instance-level game/localization version cache."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from swgoh_comlink import SwgohComlink, SwgohComlinkAsync
+from swgoh_comlink.exceptions import SwgohComlinkException, SwgohComlinkValueError
+
+# Not every test exercises all three mocked endpoints.
+pytestmark = [pytest.mark.httpx_mock(assert_all_responses_were_requested=False)]
+
+BASE_URL = "http://localhost:3000"
+METADATA = {
+    "latestGamedataVersion": "game-v1",
+    "latestLocalizationBundleVersion": "lang-v1",
+}
+
+
+def _metadata_requests(httpx_mock: HTTPXMock) -> list:
+    return [r for r in httpx_mock.get_requests() if r.url.path == "/metadata"]
+
+
+def _mock_endpoints(httpx_mock: HTTPXMock, metadata: dict | None = None) -> None:
+    httpx_mock.add_response(url=f"{BASE_URL}/metadata", json=metadata or METADATA, is_reusable=True)
+    httpx_mock.add_response(url=f"{BASE_URL}/data", json={"units": []}, is_reusable=True)
+    httpx_mock.add_response(url=f"{BASE_URL}/localization", json={"localizationBundle": ""}, is_reusable=True)
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> dict[str, float]:
+    """Controllable monotonic clock for cache expiry."""
+    state = {"t": 1000.0}
+    monkeypatch.setattr("swgoh_comlink._base._now", lambda: state["t"])
+    return state
+
+
+# ── Sync client ──────────────────────────────────────────────────────────
+
+
+def test_repeated_game_data_calls_hit_metadata_once(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_data()
+    client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+
+def test_cache_shared_between_game_data_and_localization(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_data()
+    client.get_localization()
+
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+
+def test_ttl_expiry_triggers_refetch(httpx_mock: HTTPXMock, clock: dict[str, float]):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL, version_cache_ttl=60.0)
+
+    client.get_game_data()
+    clock["t"] += 59.0
+    client.get_game_data()
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+    clock["t"] += 2.0  # past the 60s TTL
+    client.get_game_data()
+    assert len(_metadata_requests(httpx_mock)) == 2
+
+
+def test_ttl_zero_disables_caching(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL, version_cache_ttl=0)
+
+    client.get_game_data()
+    client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 2
+
+
+def test_infinite_ttl_caches_forever(httpx_mock: HTTPXMock, clock: dict[str, float]):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL, version_cache_ttl=math.inf)
+
+    client.get_game_data()
+    clock["t"] += 10**9
+    client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+
+def test_invalidate_version_cache_forces_refetch(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_data()
+    client.invalidate_version_cache()
+    client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 2
+
+
+def test_get_latest_game_data_version_refresh_bypasses_cache(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    versions = client.get_latest_game_data_version()
+    assert versions == {"game": "game-v1", "language": "lang-v1"}
+    assert client.get_latest_game_data_version() == versions
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+    client.get_latest_game_data_version(refresh=True)
+    assert len(_metadata_requests(httpx_mock)) == 2
+
+
+def test_get_game_metadata_populates_cache(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_metadata()
+    client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+
+def test_get_game_metadata_with_enums_does_not_populate_cache(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_metadata(enums=True)
+    client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 2
+
+
+def test_explicit_version_skips_metadata_entirely(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_data(version="explicit-version")
+    client.get_localization(localization_id="explicit-loc-id")
+
+    assert len(_metadata_requests(httpx_mock)) == 0
+
+
+def test_partial_metadata_supports_game_data_only(httpx_mock: HTTPXMock):
+    """A /metadata response missing the localization key still serves get_game_data."""
+    _mock_endpoints(httpx_mock, metadata={"latestGamedataVersion": "game-only"})
+    client = SwgohComlink(url=BASE_URL)
+
+    client.get_game_data()
+
+    with pytest.raises(SwgohComlinkException, match="latestLocalizationBundleVersion"):
+        client.get_localization()
+
+
+def test_negative_ttl_rejected():
+    with pytest.raises(SwgohComlinkValueError):
+        SwgohComlink(url=BASE_URL, version_cache_ttl=-1)
+
+
+# ── Async client ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_repeated_game_data_calls_hit_metadata_once(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    async with SwgohComlinkAsync(url=BASE_URL) as client:
+        await client.get_game_data()
+        await client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_cold_calls_single_flight(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    async with SwgohComlinkAsync(url=BASE_URL) as client:
+        await asyncio.gather(client.get_game_data(), client.get_game_data(), client.get_localization())
+
+    assert len(_metadata_requests(httpx_mock)) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_zero_disables_caching(httpx_mock: HTTPXMock):
+    _mock_endpoints(httpx_mock)
+    async with SwgohComlinkAsync(url=BASE_URL, version_cache_ttl=0) as client:
+        await client.get_game_data()
+        await client.get_game_data()
+
+    assert len(_metadata_requests(httpx_mock)) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_invalidate_and_refresh(httpx_mock: HTTPXMock, clock: dict[str, float]):
+    _mock_endpoints(httpx_mock)
+    async with SwgohComlinkAsync(url=BASE_URL, version_cache_ttl=60.0) as client:
+        await client.get_game_data()
+        client.invalidate_version_cache()
+        await client.get_game_data()
+        assert len(_metadata_requests(httpx_mock)) == 2
+
+        clock["t"] += 61.0
+        versions = await client.get_latest_game_data_version()
+        assert versions == {"game": "game-v1", "language": "lang-v1"}
+        assert len(_metadata_requests(httpx_mock)) == 3


### PR DESCRIPTION
## [v2.3.0](https://github.com/swgoh-utils/comlink-python/compare/v2.2.0...v2.3.0) (2026-08-03)

### Features

- **cache:** cache game/localization versions from /metadata with configurable TTL (#117) ([d351759](https://github.com/swgoh-utils/comlink-python/commit/d35175900932c79e5836f383fb6b3ce8dd39f6d9))
- **cache:** cache game/localization versions from /metadata with configurable TTL ([8cdd771](https://github.com/swgoh-utils/comlink-python/commit/8cdd7719619ac7b83ceb66c069825572e17d018a))

### Bug Fixes

- **hmac:** sign the bytes actually sent so empty-payload POSTs validate ([943fd7f](https://github.com/swgoh-utils/comlink-python/commit/943fd7ff490813a74ad50d7c4e4c35ef76b3e79d))
- **tests:** call get_game_data with items= instead of the rejected request_segment ([60c19bf](https://github.com/swgoh-utils/comlink-python/commit/60c19bf390818d0610802a1cd3a3ca7f1cb59829))
- **client:** send clientSpecs key expected by /metadata endpoint ([1909912](https://github.com/swgoh-utils/comlink-python/commit/1909912fc10b1deb822b816b46a0e7577da7e422))
- **exceptions:** stop logging tracebacks from exception constructors ([f841fa8](https://github.com/swgoh-utils/comlink-python/commit/f841fa88bd64abc6a66326ee0654e367976733ce))

### Docs

- **changelog:** update for v2.2.0 ([7b917de](https://github.com/swgoh-utils/comlink-python/commit/7b917dea5ce146c2cce9bbd90b436ba010f01207))