### PR TITLE
ci(release): trigger the back-merge on workflow_run so it actually fires

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,7 +1,13 @@
 name: back-merge main into develop
 
-# Fires when a release is published. Pushes a branch at main's tip so the post-release
-# state of main (changelog + tag lineage) can be merged back into develop.
+# Runs after the release workflow finishes. Pushes a branch at main's tip so the
+# post-release state of main (changelog + tag lineage) can be merged back into develop.
+#
+# NOT triggered by `release: published`, despite that being the obvious choice. release.yml
+# creates the release with `gh release create` under the default GITHUB_TOKEN, and GitHub
+# suppresses workflow triggers for events raised by that token — so a `release` trigger
+# never fires. It never fired for v2.2.0 or v2.3.0 either; both back-merges were done by
+# hand. `workflow_run` is not subject to that suppression, so it is used instead.
 #
 # Like prepare-release, this workflow deliberately does NOT open the pull request. A PR
 # opened by github-actions[bot] with the default GITHUB_TOKEN does not trigger the
@@ -13,8 +19,12 @@ name: back-merge main into develop
 # reason to commit a body file.
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["comlink-python release"]
+    types: [completed]
+  # Manual escape hatch: lets a maintainer stage the back-merge without cutting a release,
+  # and makes the workflow testable without waiting for one.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -22,6 +32,11 @@ permissions:
 jobs:
   backmerge:
     runs-on: ubuntu-latest
+    # workflow_run fires on completion regardless of outcome — only stage a back-merge
+    # when the release actually succeeded.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The back-merge workflow has never executed. Not once — `gh run list --workflow=backmerge.yml` is empty across both v2.2.0 and v2.3.0, which is why both back-merges were done by hand.

## Cause

[release.yml](.github/workflows/release.yml) creates the GitHub Release with `gh release create` under the default `GITHUB_TOKEN`. GitHub deliberately suppresses workflow triggers for events raised by that token, to prevent workflows recursively triggering themselves. So `on: release: types: [published]` can never fire for a release this repository creates.

This is the same class of problem as a bot-authored PR not running `pull_request` checks — the constraint that shaped #125 and #126.

Worth being explicit: #126 rewrote this workflow's body, and that work was correct but inert, because the workflow it improved was never being invoked.

## Fix

```yaml
on:
  workflow_run:
    workflows: ["comlink-python release"]
    types: [completed]
  workflow_dispatch:
```

`workflow_run` is not subject to the same suppression, so it fires when the release workflow finishes. The workflow name is matched against `release.yml`'s own `name:` — verified in CI rather than eyeballed.

`workflow_run` fires on completion regardless of outcome, so the job is guarded:

```yaml
if: >-
  github.event_name == 'workflow_dispatch' ||
  github.event.workflow_run.conclusion == 'success'
```

A failed release no longer stages a back-merge.

`workflow_dispatch` is added as a manual escape hatch — it makes the workflow testable without cutting a release, and lets a maintainer stage a back-merge whenever `main` and `develop` drift.

## One deployment caveat

`workflow_run` only fires for workflow files present on the **default branch**. `main` currently carries the old `release:`-triggered version, so this fix does not take effect until it reaches `main` via the next release promotion. The v2.4.0 back-merge is the first one that can fire automatically; until then, `workflow_dispatch` is available the moment this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
