### PR TITLE
ci: bump Comlink integration image to 4.5.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,14 +24,14 @@ jobs:
       # Bump this tag on purpose, and keep both services on the same tag.
       # 4.4.2 fixes the /data fetch that 4.4.0 and 4.4.1 could not complete.
       comlink:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.5.0
         env:
           APP_NAME: comlink-python-integration-tests
         ports:
           - 3000:3000
 
       comlink-hmac:
-        image: ghcr.io/swgoh-utils/swgoh-comlink:4.4.2
+        image: ghcr.io/swgoh-utils/swgoh-comlink:4.5.0
         env:
           APP_NAME: comlink-python-hmac-integration-tests
           ACCESS_KEY: ${{ secrets.COMLINK_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

Bumps the pinned Comlink image tag in the integration workflow from `4.4.2` to `4.5.0`, keeping both the `comlink` and `comlink-hmac` services on the same tag as required by the pinning comment in the workflow.

## Changes

- `.github/workflows/integration.yml`: `comlink` service image `4.4.2` -> `4.5.0`
- `.github/workflows/integration.yml`: `comlink-hmac` service image `4.4.2` -> `4.5.0`

## Note

The explanatory comment above the services still references `4.4.2` ("4.4.2 fixes the /data fetch that 4.4.0 and 4.4.1 could not complete"). That line was left as historical context since there is no stated rationale for 4.5.0 to substitute -- happy to update or drop it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
